### PR TITLE
CLI scaffold (ironcompass command)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Web Dashboard (read-only visualization)
 
 ```bash
 # Daily metrics
-ironcompass log --date 2026-03-05 --weight 174.5 --energy 3 --alcohol false
+ironcompass log daily --date 2026-03-05 --weight 174.5 --energy 3 --no-alcohol
 ironcompass log sleep --apple 78 --oura 85 --hours 7.2 --mouth-tape --no-cpap
 ironcompass log fasting --protocol 16:8 --start 12:00 --end 20:00 --compliant
 ironcompass log bp --systolic 128 --diastolic 78

--- a/PRD.md
+++ b/PRD.md
@@ -155,7 +155,7 @@ Valid workout types: `pickleball`, `strength`, `hike`, `golf`, `run`, `elliptica
 
 ```bash
 # Daily metrics
-ironcompass log --date 2026-03-05 --weight 175.0 --energy 3 --alcohol false
+ironcompass log daily --date 2026-03-05 --weight 175.0 --energy 3 --no-alcohol
 ironcompass log sleep --apple 78 --oura 85 --hours 7.2 --mouth-tape --no-cpap
 ironcompass log fasting --protocol 16:8 --start 12:00 --end 20:00 --compliant
 ironcompass log bp --systolic 128 --diastolic 78

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npx ironcompass status
 ### Log daily metrics
 
 ```bash
-ironcompass log --date 2026-03-05 --weight 174.5 --energy 3 --alcohol false
+ironcompass log daily --date 2026-03-05 --weight 174.5 --energy 3 --no-alcohol
 ironcompass log sleep --apple 78 --oura 85 --hours 7.2 --mouth-tape --no-cpap
 ironcompass log fasting --protocol 16:8 --start 12:00 --end 20:00 --compliant
 ironcompass log bp --systolic 128 --diastolic 78

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,205 @@
+{
+  "name": "ironcompass",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ironcompass",
+      "version": "0.1.0",
+      "dependencies": {
+        "@supabase/supabase-js": "^2",
+        "commander": "^13",
+        "dotenv": "^16"
+      },
+      "bin": {
+        "ironcompass": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20",
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.98.0.tgz",
+      "integrity": "sha512-GBH361T0peHU91AQNzOlIrjUZw9TZbB9YDRiyFgk/3Kvr3/Z1NWUZ2athWTfHhwNNi8IrW00foyFxQD9IO/Trg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.98.0.tgz",
+      "integrity": "sha512-N/xEyiNU5Org+d+PNCpv+TWniAXRzxIURxDYsS/m2I/sfAB/HcM9aM2Dmf5edj5oWb9GxID1OBaZ8NMmPXL+Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.98.0.tgz",
+      "integrity": "sha512-v6e9WeZuJijzUut8HyXu6gMqWFepIbaeaMIm1uKzei4yLg9bC9OtEW9O14LE/9ezqNbSAnSLO5GtOLFdm7Bpkg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.98.0.tgz",
+      "integrity": "sha512-rOWt28uGyFipWOSd+n0WVMr9kUXiWaa7J4hvyLCIHjRFqWm1z9CaaKAoYyfYMC1Exn3WT8WePCgiVhlAtWC2yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.98.0.tgz",
+      "integrity": "sha512-tzr2mG+v7ILSAZSfZMSL9OPyIH4z1ikgQ8EcQTKfMRz4EwmlFt3UnJaGzSOxyvF5b+fc9So7qdSUWTqGgeLokQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.98.0.tgz",
+      "integrity": "sha512-Ohc97CtInLwZyiSASz7tT9/Abm/vqnIbO9REp+PivVUII8UZsuI3bngRQnYgJdFoOIwvaEII1fX1qy8x0CyNiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.98.0",
+        "@supabase/functions-js": "2.98.0",
+        "@supabase/postgrest-js": "2.98.0",
+        "@supabase/realtime-js": "2.98.0",
+        "@supabase/storage-js": "2.98.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "ironcompass",
+  "version": "0.1.0",
+  "description": "IronCompass health tracking CLI",
+  "type": "module",
+  "bin": {
+    "ironcompass": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc && chmod +x dist/index.js",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "node --test --experimental-strip-types test/*.test.ts"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2",
+    "commander": "^13",
+    "dotenv": "^16"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5"
+  }
+}

--- a/cli/src/commands/log.ts
+++ b/cli/src/commands/log.ts
@@ -1,0 +1,126 @@
+import { Command, Option } from "commander";
+import { fail } from "../output.js";
+
+function todayDate(): string {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+const WORKOUT_TYPES = [
+  "pickleball", "strength", "hike", "golf", "run",
+  "elliptical", "mobility", "sauna", "hot_tub", "other",
+] as const;
+
+export function registerLogCommands(program: Command): void {
+  const today = todayDate();
+  const log = program
+    .command("log")
+    .description("Log health data");
+
+  log
+    .command("daily")
+    .description("Log daily metrics (weight, energy, alcohol)")
+    .option("--date <date>", "Date (YYYY-MM-DD)", today)
+    .option("--weight <lbs>", "Weight in pounds")
+    .option("--energy <1-5>", "Energy level 1-5")
+    .option("--alcohol", "Alcohol consumed")
+    .option("--no-alcohol", "No alcohol consumed")
+    .option("--notes <text>", "Notes")
+    .action(() => fail("Not implemented yet — see issue #4"));
+
+  log
+    .command("sleep")
+    .description("Log sleep data")
+    .option("--date <date>", "Date (YYYY-MM-DD)", today)
+    .option("--apple <score>", "Apple Watch sleep score")
+    .option("--oura <score>", "Oura Ring sleep score")
+    .option("--hours <hours>", "Hours slept")
+    .option("--cpap", "CPAP used")
+    .option("--no-cpap", "No CPAP")
+    .option("--mouth-tape", "Mouth tape used")
+    .option("--no-mouth-tape", "No mouth tape")
+    .option("--notes <text>", "Notes")
+    .action(() => fail("Not implemented yet — see issue #4"));
+
+  log
+    .command("fasting")
+    .description("Log fasting window")
+    .option("--date <date>", "Date (YYYY-MM-DD)", today)
+    .option("--protocol <type>", "Protocol (16:8, 18:6, OMAD)")
+    .option("--start <time>", "Window start (HH:MM)")
+    .option("--end <time>", "Window end (HH:MM)")
+    .option("--compliant", "Stuck to protocol")
+    .option("--no-compliant", "Did not comply")
+    .action(() => fail("Not implemented yet — see issue #4"));
+
+  log
+    .command("bp")
+    .description("Log blood pressure")
+    .option("--date <date>", "Date (YYYY-MM-DD)", today)
+    .requiredOption("--systolic <mmHg>", "Systolic pressure")
+    .requiredOption("--diastolic <mmHg>", "Diastolic pressure")
+    .option("--time <time>", "Time of reading (HH:MM)")
+    .action(() => fail("Not implemented yet — see issue #4"));
+
+  log
+    .command("workout")
+    .description("Log a workout")
+    .option("--date <date>", "Date (YYYY-MM-DD)", today)
+    .addOption(new Option("--type <type>", "Workout type").choices(WORKOUT_TYPES as unknown as string[]).makeOptionMandatory())
+    .option("--duration <min>", "Duration in minutes")
+    .option("--distance <miles>", "Distance in miles")
+    .option("--elevation <ft>", "Elevation gain in feet")
+    .option("--calories <cal>", "Calories burned")
+    .option("--hr <bpm>", "Average heart rate")
+    .option("--notes <text>", "Notes")
+    .option("--planned", "Was planned")
+    .option("--no-planned", "Was not planned")
+    .option("--completed", "Was completed")
+    .option("--no-completed", "Was not completed")
+    .action(() => fail("Not implemented yet — see issue #4"));
+
+  log
+    .command("meal")
+    .description("Log a meal")
+    .option("--date <date>", "Date (YYYY-MM-DD)", today)
+    .option("--time <time>", "Meal time (HH:MM)")
+    .requiredOption("--name <name>", "Meal name")
+    .option("--description <text>", "Description")
+    .option("--protein <g>", "Protein grams")
+    .option("--fat <g>", "Fat grams")
+    .option("--carbs <g>", "Carbs grams")
+    .option("--calories <cal>", "Calories")
+    .option("--notes <text>", "Notes")
+    .action(() => fail("Not implemented yet — see issue #4"));
+
+  log
+    .command("pullups")
+    .description("Log pullup count")
+    .option("--date <date>", "Date (YYYY-MM-DD)", today)
+    .requiredOption("--total <count>", "Total reps")
+    .option("--sets <reps>", "Reps per set (comma-separated, e.g. 3,3,3)")
+    .action(() => fail("Not implemented yet — see issue #4"));
+
+  log
+    .command("supplements")
+    .description("Log supplements taken")
+    .option("--date <date>", "Date (YYYY-MM-DD)", today)
+    .requiredOption("--taken <list>", "Supplements (comma-separated)")
+    .action(() => fail("Not implemented yet — see issue #4"));
+
+  log
+    .command("bodycomp")
+    .description("Log body composition (Hume Body Pod)")
+    .option("--date <date>", "Date (YYYY-MM-DD)", today)
+    .option("--fat <pct>", "Body fat percentage")
+    .option("--muscle <lbs>", "Muscle mass in pounds")
+    .option("--bone <lbs>", "Bone mass in pounds")
+    .option("--water <pct>", "Body water percentage")
+    .option("--visceral <score>", "Visceral fat score")
+    .option("--bmr <cal>", "Basal metabolic rate")
+    .option("--notes <text>", "Notes")
+    .action(() => fail("Not implemented yet — see issue #4"));
+}

--- a/cli/src/commands/query.ts
+++ b/cli/src/commands/query.ts
@@ -1,0 +1,32 @@
+import { Command } from "commander";
+import { fail } from "../output.js";
+
+export function registerQueryCommands(program: Command): void {
+  program
+    .command("today")
+    .description("Today's full summary")
+    .action(() => fail("Not implemented yet — see issue #5"));
+
+  program
+    .command("week")
+    .description("Weekly summary")
+    .action(() => fail("Not implemented yet — see issue #5"));
+
+  program
+    .command("trend")
+    .description("Trend data for a metric")
+    .argument("<metric>", "Metric to trend (weight, sleep, etc.)")
+    .option("--days <n>", "Number of days", "30")
+    .action(() => fail("Not implemented yet — see issue #5"));
+
+  program
+    .command("streak")
+    .description("Current streak for a metric")
+    .argument("<metric>", "Metric (alcohol-free, fasting)")
+    .action(() => fail("Not implemented yet — see issue #5"));
+
+  program
+    .command("status")
+    .description("Overall dashboard summary")
+    .action(() => fail("Not implemented yet — see issue #5"));
+}

--- a/cli/src/db.ts
+++ b/cli/src/db.ts
@@ -1,0 +1,32 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { config } from "dotenv";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import type { Database } from "./types/database.js";
+
+let _client: SupabaseClient<Database> | null = null;
+
+export function getSupabase(): SupabaseClient<Database> {
+  if (_client) return _client;
+
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  config({ path: resolve(__dirname, "../.env.local") });
+  config({ path: resolve(__dirname, "../../.env.local") });
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !key) {
+    console.error(
+      JSON.stringify({
+        ok: false,
+        error:
+          "Missing SUPABASE_URL/NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY. Set in environment or .env.local",
+      })
+    );
+    process.exit(1);
+  }
+
+  _client = createClient<Database>(url, key);
+  return _client;
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+import { Command } from "commander";
+import { registerLogCommands } from "./commands/log.js";
+import { registerQueryCommands } from "./commands/query.js";
+
+const program = new Command();
+
+program
+  .name("ironcompass")
+  .description("IronCompass health tracking CLI")
+  .version("0.1.0");
+
+registerLogCommands(program);
+registerQueryCommands(program);
+
+program.parseAsync();

--- a/cli/src/lib/ensure-daily-entry.ts
+++ b/cli/src/lib/ensure-daily-entry.ts
@@ -1,0 +1,11 @@
+import { getSupabase } from "../db.js";
+
+export async function ensureDailyEntry(date: string): Promise<void> {
+  const { error } = await getSupabase()
+    .from("daily_entries")
+    .upsert({ date }, { onConflict: "date", ignoreDuplicates: true });
+
+  if (error) {
+    throw new Error(`Failed to ensure daily entry: ${error.message}`);
+  }
+}

--- a/cli/src/output.ts
+++ b/cli/src/output.ts
@@ -1,0 +1,9 @@
+export function success(data: unknown): never {
+  console.log(JSON.stringify({ ok: true, data }));
+  process.exit(0);
+}
+
+export function fail(error: string): never {
+  console.error(JSON.stringify({ ok: false, error }));
+  process.exit(1);
+}

--- a/cli/src/types/database.ts
+++ b/cli/src/types/database.ts
@@ -1,0 +1,530 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.1"
+  }
+  public: {
+    Tables: {
+      blood_pressure: {
+        Row: {
+          created_at: string | null
+          date: string
+          diastolic: number
+          id: string
+          systolic: number
+          time: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          date: string
+          diastolic: number
+          id?: string
+          systolic: number
+          time?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          date?: string
+          diastolic?: number
+          id?: string
+          systolic?: number
+          time?: string | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "blood_pressure_date_fkey"
+            columns: ["date"]
+            isOneToOne: false
+            referencedRelation: "daily_entries"
+            referencedColumns: ["date"]
+          },
+        ]
+      }
+      body_composition: {
+        Row: {
+          bmr: number | null
+          body_fat_pct: number | null
+          body_water_pct: number | null
+          bone_mass_lbs: number | null
+          created_at: string | null
+          date: string
+          muscle_mass_lbs: number | null
+          notes: string | null
+          updated_at: string | null
+          visceral_fat: number | null
+        }
+        Insert: {
+          bmr?: number | null
+          body_fat_pct?: number | null
+          body_water_pct?: number | null
+          bone_mass_lbs?: number | null
+          created_at?: string | null
+          date: string
+          muscle_mass_lbs?: number | null
+          notes?: string | null
+          updated_at?: string | null
+          visceral_fat?: number | null
+        }
+        Update: {
+          bmr?: number | null
+          body_fat_pct?: number | null
+          body_water_pct?: number | null
+          bone_mass_lbs?: number | null
+          created_at?: string | null
+          date?: string
+          muscle_mass_lbs?: number | null
+          notes?: string | null
+          updated_at?: string | null
+          visceral_fat?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "body_composition_date_fkey"
+            columns: ["date"]
+            isOneToOne: true
+            referencedRelation: "daily_entries"
+            referencedColumns: ["date"]
+          },
+        ]
+      }
+      daily_entries: {
+        Row: {
+          alcohol: boolean | null
+          created_at: string | null
+          date: string
+          energy: number | null
+          notes: string | null
+          updated_at: string | null
+          weight: number | null
+        }
+        Insert: {
+          alcohol?: boolean | null
+          created_at?: string | null
+          date: string
+          energy?: number | null
+          notes?: string | null
+          updated_at?: string | null
+          weight?: number | null
+        }
+        Update: {
+          alcohol?: boolean | null
+          created_at?: string | null
+          date?: string
+          energy?: number | null
+          notes?: string | null
+          updated_at?: string | null
+          weight?: number | null
+        }
+        Relationships: []
+      }
+      fasting: {
+        Row: {
+          compliant: boolean | null
+          created_at: string | null
+          date: string
+          protocol: string | null
+          updated_at: string | null
+          window_end: string | null
+          window_start: string | null
+        }
+        Insert: {
+          compliant?: boolean | null
+          created_at?: string | null
+          date: string
+          protocol?: string | null
+          updated_at?: string | null
+          window_end?: string | null
+          window_start?: string | null
+        }
+        Update: {
+          compliant?: boolean | null
+          created_at?: string | null
+          date?: string
+          protocol?: string | null
+          updated_at?: string | null
+          window_end?: string | null
+          window_start?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fasting_date_fkey"
+            columns: ["date"]
+            isOneToOne: true
+            referencedRelation: "daily_entries"
+            referencedColumns: ["date"]
+          },
+        ]
+      }
+      meals: {
+        Row: {
+          calories: number | null
+          carbs_g: number | null
+          created_at: string | null
+          date: string
+          description: string | null
+          fat_g: number | null
+          id: string
+          name: string | null
+          notes: string | null
+          protein_g: number | null
+          time: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          calories?: number | null
+          carbs_g?: number | null
+          created_at?: string | null
+          date: string
+          description?: string | null
+          fat_g?: number | null
+          id?: string
+          name?: string | null
+          notes?: string | null
+          protein_g?: number | null
+          time?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          calories?: number | null
+          carbs_g?: number | null
+          created_at?: string | null
+          date?: string
+          description?: string | null
+          fat_g?: number | null
+          id?: string
+          name?: string | null
+          notes?: string | null
+          protein_g?: number | null
+          time?: string | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "meals_date_fkey"
+            columns: ["date"]
+            isOneToOne: false
+            referencedRelation: "daily_entries"
+            referencedColumns: ["date"]
+          },
+        ]
+      }
+      pullups: {
+        Row: {
+          created_at: string | null
+          date: string
+          sets: number[] | null
+          total_count: number
+          updated_at: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          date: string
+          sets?: number[] | null
+          total_count: number
+          updated_at?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          date?: string
+          sets?: number[] | null
+          total_count?: number
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "pullups_date_fkey"
+            columns: ["date"]
+            isOneToOne: true
+            referencedRelation: "daily_entries"
+            referencedColumns: ["date"]
+          },
+        ]
+      }
+      sleep: {
+        Row: {
+          apple_score: number | null
+          avg_hr_sleep: number | null
+          avg_hrv: number | null
+          cpap: boolean | null
+          created_at: string | null
+          date: string
+          hours: number | null
+          mouth_tape: boolean | null
+          notes: string | null
+          oura_readiness: number | null
+          oura_score: number | null
+          updated_at: string | null
+        }
+        Insert: {
+          apple_score?: number | null
+          avg_hr_sleep?: number | null
+          avg_hrv?: number | null
+          cpap?: boolean | null
+          created_at?: string | null
+          date: string
+          hours?: number | null
+          mouth_tape?: boolean | null
+          notes?: string | null
+          oura_readiness?: number | null
+          oura_score?: number | null
+          updated_at?: string | null
+        }
+        Update: {
+          apple_score?: number | null
+          avg_hr_sleep?: number | null
+          avg_hrv?: number | null
+          cpap?: boolean | null
+          created_at?: string | null
+          date?: string
+          hours?: number | null
+          mouth_tape?: boolean | null
+          notes?: string | null
+          oura_readiness?: number | null
+          oura_score?: number | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "sleep_date_fkey"
+            columns: ["date"]
+            isOneToOne: true
+            referencedRelation: "daily_entries"
+            referencedColumns: ["date"]
+          },
+        ]
+      }
+      supplements: {
+        Row: {
+          created_at: string | null
+          date: string
+          supplements: string[]
+          updated_at: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          date: string
+          supplements: string[]
+          updated_at?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          date?: string
+          supplements?: string[]
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "supplements_date_fkey"
+            columns: ["date"]
+            isOneToOne: true
+            referencedRelation: "daily_entries"
+            referencedColumns: ["date"]
+          },
+        ]
+      }
+      workouts: {
+        Row: {
+          avg_hr: number | null
+          calories: number | null
+          completed: boolean | null
+          created_at: string | null
+          date: string
+          distance_mi: number | null
+          duration_min: number | null
+          elevation_ft: number | null
+          id: string
+          notes: string | null
+          planned: boolean | null
+          type: string
+          updated_at: string | null
+        }
+        Insert: {
+          avg_hr?: number | null
+          calories?: number | null
+          completed?: boolean | null
+          created_at?: string | null
+          date: string
+          distance_mi?: number | null
+          duration_min?: number | null
+          elevation_ft?: number | null
+          id?: string
+          notes?: string | null
+          planned?: boolean | null
+          type: string
+          updated_at?: string | null
+        }
+        Update: {
+          avg_hr?: number | null
+          calories?: number | null
+          completed?: boolean | null
+          created_at?: string | null
+          date?: string
+          distance_mi?: number | null
+          duration_min?: number | null
+          elevation_ft?: number | null
+          id?: string
+          notes?: string | null
+          planned?: boolean | null
+          type?: string
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "workouts_date_fkey"
+            columns: ["date"]
+            isOneToOne: false
+            referencedRelation: "daily_entries"
+            referencedColumns: ["date"]
+          },
+        ]
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  public: {
+    Enums: {},
+  },
+} as const

--- a/cli/test/cli.test.ts
+++ b/cli/test/cli.test.ts
@@ -1,0 +1,93 @@
+import { describe, it } from "node:test";
+import { execFileSync } from "node:child_process";
+import assert from "node:assert/strict";
+
+const CLI = "./dist/index.js";
+
+function run(...args: string[]): { stdout: string; stderr: string; exitCode: number } {
+  try {
+    const stdout = execFileSync("node", [CLI, ...args], {
+      cwd: import.meta.dirname + "/..",
+      encoding: "utf8",
+      env: { ...process.env, PATH: process.env.PATH },
+    });
+    return { stdout, stderr: "", exitCode: 0 };
+  } catch (e: any) {
+    return {
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? "",
+      exitCode: e.status ?? 1,
+    };
+  }
+}
+
+describe("ironcompass CLI", () => {
+  it("--help returns usage info with exit 0", () => {
+    const { stdout, exitCode } = run("--help");
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.includes("IronCompass health tracking CLI"));
+    assert.ok(stdout.includes("log"));
+    assert.ok(stdout.includes("today"));
+  });
+
+  it("--version returns version with exit 0", () => {
+    const { stdout, exitCode } = run("--version");
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.includes("0.1.0"));
+  });
+
+  it("log --help lists all 9 subcommands", () => {
+    const { stdout, exitCode } = run("log", "--help");
+    assert.equal(exitCode, 0);
+    for (const cmd of ["daily", "sleep", "fasting", "bp", "workout", "meal", "pullups", "supplements", "bodycomp"]) {
+      assert.ok(stdout.includes(cmd), `missing subcommand: ${cmd}`);
+    }
+  });
+
+  it("stub commands return JSON error with exit 1", () => {
+    const { stderr, exitCode } = run("today");
+    assert.equal(exitCode, 1);
+    const parsed = JSON.parse(stderr);
+    assert.equal(parsed.ok, false);
+    assert.ok(parsed.error.includes("Not implemented"));
+  });
+
+  it("log daily stub returns JSON error with exit 1", () => {
+    const { stderr, exitCode } = run("log", "daily");
+    assert.equal(exitCode, 1);
+    const parsed = JSON.parse(stderr);
+    assert.equal(parsed.ok, false);
+    assert.ok(parsed.error.includes("issue #4"));
+  });
+
+  it("workout --type validates against allowed choices", () => {
+    const { stderr, exitCode } = run("log", "workout", "--type", "swimming");
+    assert.equal(exitCode, 1);
+    assert.ok(stderr.includes("Allowed choices"));
+  });
+
+  it("workout --type accepts valid type", () => {
+    const { stderr, exitCode } = run("log", "workout", "--type", "hike");
+    assert.equal(exitCode, 1);
+    const parsed = JSON.parse(stderr);
+    assert.equal(parsed.ok, false);
+    assert.ok(parsed.error.includes("issue #4"));
+  });
+
+  it("log daily --help shows --date default as YYYY-MM-DD", () => {
+    const { stdout } = run("log", "daily", "--help");
+    assert.match(stdout, /default: "\d{4}-\d{2}-\d{2}"/);
+  });
+
+  it("bp requires --systolic and --diastolic", () => {
+    const { stderr, exitCode } = run("log", "bp");
+    assert.equal(exitCode, 1);
+    assert.ok(stderr.includes("--systolic"));
+  });
+
+  it("trend requires metric argument", () => {
+    const { stderr, exitCode } = run("trend");
+    assert.equal(exitCode, 1);
+    assert.ok(stderr.includes("metric"));
+  });
+});

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Standalone CLI package in `cli/` with Commander-based command parsing
- 9 log subcommands (daily, sleep, fasting, bp, workout, meal, pullups, supplements, bodycomp) — all stubs for #4
- 5 query commands (today, week, trend, streak, status) — all stubs for #5
- Lazy Supabase client with fail-fast env validation and generated DB types
- Workout type validation via Commander `.choices()`
- `ensureDailyEntry()` upsert helper for lazy anchor pattern
- 10 smoke tests using Node built-in test runner
- Docs updated: `log` → `log daily`, `--alcohol false` → `--no-alcohol`

Closes #3

## Test plan
- [x] `ironcompass --help` shows all commands
- [x] `ironcompass log --help` lists 9 subcommands
- [x] Stub commands return `{ ok: false, error }` JSON with exit code 1
- [x] Invalid workout type rejected at parse time
- [x] Required options enforced (bp --systolic/--diastolic)
- [x] `npm test` passes (10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)