### PR TITLE
Implement ironcompass query commands (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,17 @@ Dark theme, athletic aesthetic. Three main views:
 
 ```
 ironcompass/
+├── cli/
+│   ├── src/
+│   │   ├── commands/     # log.ts, query.ts
+│   │   ├── lib/          # date.ts, parse.ts, ensure-daily-entry.ts
+│   │   ├── types/        # database.ts (generated)
+│   │   ├── db.ts         # Supabase client
+│   │   ├── output.ts     # JSON output helpers
+│   │   └── index.ts      # CLI entry point
+│   └── test/             # CLI tests
 ├── src/
 │   └── app/              # Next.js App Router
-│       ├── page.tsx      # Dashboard home
-│       ├── layout.tsx    # Root layout
-│       └── globals.css   # Global styles
 ├── supabase/
 │   └── migrations/       # SQL migrations
 ├── CLAUDE.md             # AI project config
@@ -129,7 +135,7 @@ npm run lint      # ESLint
 
 ## Build Phases
 
-1. **Data Layer + CLI** — Supabase schema, CLI commands, log and query (current)
+1. **Data Layer + CLI** — Supabase schema, CLI commands, log and query (done)
 2. **MCP Server** — expose tools to Claude Code
 3. **Web Dashboard** — calendar view, metrics, deploy to Vercel
 4. **Integrations** — Health Auto Export, Hevy, Oura, Strava

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ Get data flowing. Log everything from the terminal. Every command returns JSON.
 | #2 | Supabase project setup + schema | **done** |
 | #3 | CLI scaffold (`ironcompass` command) | **done** |
 | #4 | `ironcompass log` commands (daily, sleep, fasting, workout, meal, pullups, bp, supplements) | **done** |
-| #5 | `ironcompass query` commands (today, week, trend, streak, status) | todo |
+| #5 | `ironcompass query` commands (today, week, trend, streak, status) | **done** |
 
 ## Phase 2: MCP Server — #6
 

--- a/cli/src/commands/log.ts
+++ b/cli/src/commands/log.ts
@@ -3,14 +3,7 @@ import { fail, success } from "../output.js";
 import { getSupabase } from "../db.js";
 import { ensureDailyEntry } from "../lib/ensure-daily-entry.js";
 import { parseNum, parseList, sparse } from "../lib/parse.js";
-
-function todayDate(): string {
-  const d = new Date();
-  const yyyy = d.getFullYear();
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}`;
-}
+import { todayDate } from "../lib/date.js";
 
 const WORKOUT_TYPES = [
   "pickleball", "strength", "hike", "golf", "run",

--- a/cli/src/commands/query.ts
+++ b/cli/src/commands/query.ts
@@ -1,32 +1,427 @@
 import { Command } from "commander";
-import { fail } from "../output.js";
+import { fail, success } from "../output.js";
+import { getSupabase } from "../db.js";
+import { todayDate, daysAgo } from "../lib/date.js";
+import { parseNum } from "../lib/parse.js";
+import type { Database } from "../types/database.js";
+
+type TableName = keyof Database["public"]["Tables"];
+
+function throwIfError({ error }: { error: any }) {
+  if (error) throw new Error(`Supabase query failed: ${error.message}`);
+}
+
+// --- fetchDay ---
+
+async function fetchDay(date: string) {
+  const sb = getSupabase();
+  const results = await Promise.all([
+    sb.from("daily_entries").select().eq("date", date).maybeSingle(),
+    sb.from("sleep").select().eq("date", date).maybeSingle(),
+    sb.from("fasting").select().eq("date", date).maybeSingle(),
+    sb.from("blood_pressure").select().eq("date", date),
+    sb.from("workouts").select().eq("date", date),
+    sb.from("meals").select().eq("date", date),
+    sb.from("pullups").select().eq("date", date).maybeSingle(),
+    sb.from("supplements").select().eq("date", date).maybeSingle(),
+    sb.from("body_composition").select().eq("date", date).maybeSingle(),
+  ]);
+  results.forEach(throwIfError);
+  const [daily, sleep, fasting, bp, workouts, meals, pullups, supplements, bodycomp] = results;
+
+  return {
+    date,
+    daily: daily.data ?? null,
+    sleep: sleep.data ?? null,
+    fasting: fasting.data ?? null,
+    blood_pressure: bp.data ?? [],
+    workouts: workouts.data ?? [],
+    meals: meals.data ?? [],
+    pullups: pullups.data ?? null,
+    supplements: supplements.data ?? null,
+    body_composition: bodycomp.data ?? null,
+  };
+}
+
+// --- fetchWeek ---
+
+function avg(nums: number[]): number | null {
+  if (nums.length === 0) return null;
+  return nums.reduce((a, b) => a + b, 0) / nums.length;
+}
+
+async function fetchWeek() {
+  const start = daysAgo(6);
+  const end = todayDate();
+  const sb = getSupabase();
+
+  const results = await Promise.all([
+    sb.from("daily_entries").select().gte("date", start).lte("date", end).order("date"),
+    sb.from("sleep").select().gte("date", start).lte("date", end).order("date"),
+    sb.from("workouts").select().gte("date", start).lte("date", end).order("date"),
+    sb.from("meals").select().gte("date", start).lte("date", end).order("date"),
+    sb.from("fasting").select().gte("date", start).lte("date", end).order("date"),
+    sb.from("pullups").select().gte("date", start).lte("date", end).order("date"),
+  ]);
+  results.forEach(throwIfError);
+  const [daily, sleep, workouts, meals, fasting, pullups] = results;
+
+  const dailyRows = daily.data ?? [];
+  const sleepRows = sleep.data ?? [];
+  const workoutRows = workouts.data ?? [];
+  const mealRows = meals.data ?? [];
+  const fastingRows = fasting.data ?? [];
+  const pullupRows = pullups.data ?? [];
+
+  // Weight delta
+  const weights = dailyRows
+    .map((r: any) => ({ date: r.date, weight: r.weight }))
+    .filter((r: any) => r.weight != null);
+  const weightDelta =
+    weights.length >= 2
+      ? weights[weights.length - 1].weight - weights[0].weight
+      : null;
+
+  // Sleep averages
+  const sleepHours = sleepRows.map((r: any) => r.hours).filter((v: any) => v != null);
+  const ouraScores = sleepRows.map((r: any) => r.oura_score).filter((v: any) => v != null);
+  const appleScores = sleepRows.map((r: any) => r.apple_score).filter((v: any) => v != null);
+
+  // Workouts
+  const completedCount = workoutRows.filter((r: any) => r.completed === true).length;
+  const plannedCount = workoutRows.filter((r: any) => r.planned === true).length;
+  const workoutTypes = [...new Set(workoutRows.map((r: any) => r.type))];
+
+  // Meals: avg daily protein and calories (only days with meals)
+  const mealsByDate: Record<string, { protein: number; calories: number }> = {};
+  for (const m of mealRows as any[]) {
+    if (!mealsByDate[m.date]) mealsByDate[m.date] = { protein: 0, calories: 0 };
+    if (m.protein_g != null) mealsByDate[m.date].protein += m.protein_g;
+    if (m.calories != null) mealsByDate[m.date].calories += m.calories;
+  }
+  const mealDays = Object.values(mealsByDate);
+  const avgDailyProtein = mealDays.length > 0 ? avg(mealDays.map((d) => d.protein)) : null;
+  const avgDailyCalories = mealDays.length > 0 ? avg(mealDays.map((d) => d.calories)) : null;
+
+  // Fasting compliance
+  const fastingCompliant = fastingRows.filter((r: any) => r.compliant === true).length;
+
+  // Alcohol
+  const alcoholTrue = dailyRows.filter((r: any) => r.alcohol === true).length;
+  const alcoholFalse = dailyRows.filter((r: any) => r.alcohol === false).length;
+
+  // Pullups
+  const pullupTotal = pullupRows.reduce((s: number, r: any) => s + (r.total_count ?? 0), 0);
+
+  return {
+    start,
+    end,
+    days_logged: dailyRows.length,
+    weight: {
+      first: weights.length > 0 ? weights[0].weight : null,
+      last: weights.length > 0 ? weights[weights.length - 1].weight : null,
+      delta: weightDelta,
+    },
+    sleep: {
+      avg_hours: avg(sleepHours),
+      avg_oura_score: avg(ouraScores),
+      avg_apple_score: avg(appleScores),
+    },
+    workouts: {
+      total: workoutRows.length,
+      completed_count: completedCount,
+      planned_count: plannedCount,
+      types: workoutTypes,
+    },
+    meals: {
+      avg_daily_protein_g: avgDailyProtein,
+      avg_daily_calories: avgDailyCalories,
+    },
+    fasting: {
+      compliant_days: fastingCompliant,
+      total_days: fastingRows.length,
+    },
+    alcohol: {
+      days_with: alcoholTrue,
+      days_without: alcoholFalse,
+    },
+    pullups: {
+      total: pullupTotal,
+      days: pullupRows.length,
+    },
+  };
+}
+
+// --- computeTrend ---
+
+const VALID_METRICS = [
+  "weight", "energy", "sleep", "hrv", "hr-sleep", "readiness",
+  "bp", "pullups", "calories", "protein", "body-fat",
+] as const;
+
+type MetricName = (typeof VALID_METRICS)[number];
+
+interface TrendConfig {
+  table: TableName;
+  columns: string[];
+  type: "single" | "multi" | "multi-daily-avg" | "daily-sum";
+}
+
+const METRIC_MAP: Record<MetricName, TrendConfig> = {
+  weight: { table: "daily_entries", columns: ["weight"], type: "single" },
+  energy: { table: "daily_entries", columns: ["energy"], type: "single" },
+  sleep: { table: "sleep", columns: ["oura_score", "apple_score", "hours"], type: "multi" },
+  hrv: { table: "sleep", columns: ["avg_hrv"], type: "single" },
+  "hr-sleep": { table: "sleep", columns: ["avg_hr_sleep"], type: "single" },
+  readiness: { table: "sleep", columns: ["oura_readiness"], type: "single" },
+  bp: { table: "blood_pressure", columns: ["systolic", "diastolic"], type: "multi-daily-avg" },
+  pullups: { table: "pullups", columns: ["total_count"], type: "single" },
+  calories: { table: "meals", columns: ["calories"], type: "daily-sum" },
+  protein: { table: "meals", columns: ["protein_g"], type: "daily-sum" },
+  "body-fat": { table: "body_composition", columns: ["body_fat_pct"], type: "single" },
+};
+
+function singleSummary(values: number[]) {
+  if (values.length === 0) return { min: null, max: null, avg: null, delta: null, count: 0 };
+  return {
+    min: Math.min(...values),
+    max: Math.max(...values),
+    avg: avg(values),
+    delta: values.length >= 2 ? values[values.length - 1] - values[0] : null,
+    count: values.length,
+  };
+}
+
+function multiSummaries(columns: string[], points: any[]) {
+  const summaries: Record<string, any> = {};
+  for (const col of columns) {
+    const vals = points.map((p: any) => p[col]).filter((v: any) => v != null);
+    summaries[col] = singleSummary(vals);
+  }
+  return summaries;
+}
+
+async function computeTrend(metric: string, days: number) {
+  if (!VALID_METRICS.includes(metric as MetricName)) {
+    throw new Error(`Unknown metric "${metric}". Valid metrics: ${VALID_METRICS.join(", ")}`);
+  }
+  if (!Number.isInteger(days) || days <= 0) {
+    throw new Error(`--days must be a positive integer, got "${days}"`);
+  }
+
+  const cfg = METRIC_MAP[metric as MetricName];
+  const start = daysAgo(days - 1);
+  const end = todayDate();
+  const sb = getSupabase();
+  const selectCols = ["date", ...cfg.columns].join(", ");
+
+  const { data: rows, error } = await sb
+    .from(cfg.table)
+    .select(selectCols)
+    .gte("date", start)
+    .lte("date", end)
+    .order("date", { ascending: true });
+
+  if (error) throw new Error(`Query failed: ${error.message}`);
+  const data = rows ?? [];
+
+  if (cfg.type === "single") {
+    const col = cfg.columns[0];
+    const points = data
+      .filter((r: any) => r[col] != null)
+      .map((r: any) => ({ date: r.date, value: r[col] }));
+    return {
+      metric, days, start, end, points,
+      summary: singleSummary(points.map((p: any) => p.value)),
+    };
+  }
+
+  if (cfg.type === "multi-daily-avg") {
+    // Average multiple readings per day, then trend over daily averages
+    const byDate: Record<string, Record<string, number[]>> = {};
+    for (const r of data as any[]) {
+      if (!byDate[r.date]) {
+        byDate[r.date] = Object.fromEntries(cfg.columns.map(c => [c, []]));
+      }
+      for (const col of cfg.columns) {
+        if (r[col] != null) byDate[r.date][col].push(r[col]);
+      }
+    }
+    const points = Object.entries(byDate)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, cols]) => {
+        const point: any = { date };
+        for (const col of cfg.columns) point[col] = avg(cols[col]);
+        return point;
+      });
+    return { metric, days, start, end, points, summaries: multiSummaries(cfg.columns, points) };
+  }
+
+  if (cfg.type === "multi") {
+    const points = data.map((r: any) => {
+      const point: any = { date: r.date };
+      for (const col of cfg.columns) point[col] = r[col] ?? null;
+      return point;
+    });
+    return { metric, days, start, end, points, summaries: multiSummaries(cfg.columns, points) };
+  }
+
+  // daily-sum
+  const col = cfg.columns[0];
+  const byDate: Record<string, number> = {};
+  for (const r of data as any[]) {
+    if (r[col] != null) {
+      byDate[r.date] = (byDate[r.date] ?? 0) + r[col];
+    }
+  }
+  const points = Object.entries(byDate)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, value]) => ({ date, value }));
+  return {
+    metric, days, start, end, points,
+    summary: singleSummary(points.map((p) => p.value)),
+  };
+}
+
+// --- computeStreak ---
+
+const VALID_STREAKS = ["alcohol-free", "fasting", "workout", "logging"] as const;
+type StreakName = (typeof VALID_STREAKS)[number];
+
+interface StreakConfig {
+  table: TableName;
+  select: string;
+  pass: (row: any) => boolean;
+}
+
+const STREAK_MAP: Record<StreakName, StreakConfig> = {
+  "alcohol-free": { table: "daily_entries", select: "date, alcohol", pass: (r) => r.alcohol === false },
+  fasting: { table: "fasting", select: "date, compliant", pass: (r) => r.compliant === true },
+  workout: { table: "workouts", select: "date", pass: () => true },
+  logging: { table: "daily_entries", select: "date", pass: () => true },
+};
+
+async function computeStreak(metric: string) {
+  if (!VALID_STREAKS.includes(metric as StreakName)) {
+    throw new Error(`Unknown streak "${metric}". Valid streaks: ${VALID_STREAKS.join(", ")}`);
+  }
+
+  const cfg = STREAK_MAP[metric as StreakName];
+  const today = todayDate();
+  const sb = getSupabase();
+
+  // Use date range instead of row limit to handle multi-row tables (e.g. workouts)
+  const rangeStart = daysAgo(365);
+  const { data, error } = await sb
+    .from(cfg.table)
+    .select(cfg.select)
+    .gte("date", rangeStart)
+    .lte("date", today)
+    .order("date", { ascending: false });
+  if (error) throw new Error(`Supabase query failed: ${error.message}`);
+  const rows = data ?? [];
+
+  const rowsByDate = new Map<string, any>();
+  for (const r of rows as any[]) {
+    if (!rowsByDate.has(r.date)) rowsByDate.set(r.date, r);
+  }
+
+  const earliest = rangeStart;
+  let count = 0;
+  for (let i = 0; ; i++) {
+    const d = daysAgo(i);
+    if (d < earliest) break;
+    const row = rowsByDate.get(d);
+    if (row && cfg.pass(row)) { count++; }
+    else break;
+  }
+
+  const startDate = count > 0 ? daysAgo(count - 1) : null;
+  return { metric, current_streak: count, start_date: startDate, as_of: today };
+}
+
+// --- register commands ---
 
 export function registerQueryCommands(program: Command): void {
   program
     .command("today")
     .description("Today's full summary")
-    .action(() => fail("Not implemented yet — see issue #5"));
+    .option("--date <date>", "Date (YYYY-MM-DD)", todayDate())
+    .action(async (opts) => {
+      try {
+        success(await fetchDay(opts.date));
+      } catch (e: any) {
+        fail(e.message ?? String(e));
+      }
+    });
 
   program
     .command("week")
     .description("Weekly summary")
-    .action(() => fail("Not implemented yet — see issue #5"));
+    .action(async () => {
+      try {
+        success(await fetchWeek());
+      } catch (e: any) {
+        fail(e.message ?? String(e));
+      }
+    });
 
   program
     .command("trend")
     .description("Trend data for a metric")
-    .argument("<metric>", "Metric to trend (weight, sleep, etc.)")
+    .argument("<metric>", `Metric to trend (${VALID_METRICS.join(", ")})`)
     .option("--days <n>", "Number of days", "30")
-    .action(() => fail("Not implemented yet — see issue #5"));
+    .action(async (metric, opts) => {
+      try {
+        const days = parseNum("days", opts.days)!;
+        success(await computeTrend(metric, days));
+      } catch (e: any) {
+        fail(e.message ?? String(e));
+      }
+    });
 
   program
     .command("streak")
     .description("Current streak for a metric")
-    .argument("<metric>", "Metric (alcohol-free, fasting)")
-    .action(() => fail("Not implemented yet — see issue #5"));
+    .argument("<metric>", `Metric (${VALID_STREAKS.join(", ")})`)
+    .action(async (metric) => {
+      try {
+        success(await computeStreak(metric));
+      } catch (e: any) {
+        fail(e.message ?? String(e));
+      }
+    });
 
   program
     .command("status")
     .description("Overall dashboard summary")
-    .action(() => fail("Not implemented yet — see issue #5"));
+    .action(async () => {
+      try {
+        const today = todayDate();
+        const [day, week, alcoholStreak, fastingStreak, workoutStreak, loggingStreak, weightTrend] =
+          await Promise.all([
+            fetchDay(today),
+            fetchWeek(),
+            computeStreak("alcohol-free"),
+            computeStreak("fasting"),
+            computeStreak("workout"),
+            computeStreak("logging"),
+            computeTrend("weight", 7),
+          ]);
+
+        success({
+          today: day,
+          week,
+          streaks: {
+            alcohol_free: alcoholStreak,
+            fasting: fastingStreak,
+            workout: workoutStreak,
+            logging: loggingStreak,
+          },
+          weight_trend_7d: weightTrend,
+        });
+      } catch (e: any) {
+        fail(e.message ?? String(e));
+      }
+    });
 }

--- a/cli/src/lib/date.ts
+++ b/cli/src/lib/date.ts
@@ -1,0 +1,16 @@
+export function todayDate(): string {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+export function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}

--- a/cli/test/cli.test.ts
+++ b/cli/test/cli.test.ts
@@ -44,12 +44,10 @@ describe("ironcompass CLI", () => {
     }
   });
 
-  it("stub commands return JSON error with exit 1", () => {
-    const { stderr, exitCode } = run("today");
-    assert.equal(exitCode, 1);
-    const parsed = JSON.parse(stderr);
-    assert.equal(parsed.ok, false);
-    assert.ok(parsed.error.includes("Not implemented"));
+  it("today --help shows --date option", () => {
+    const { stdout, exitCode } = run("today", "--help");
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.includes("--date"));
   });
 
   it("workout --type validates against allowed choices", () => {
@@ -73,6 +71,48 @@ describe("ironcompass CLI", () => {
     const { stderr, exitCode } = run("trend");
     assert.equal(exitCode, 1);
     assert.ok(stderr.includes("metric"));
+  });
+
+  it("trend with invalid metric fails with valid metric list", () => {
+    const { stderr, exitCode } = run("trend", "bogus");
+    assert.equal(exitCode, 1);
+    const parsed = JSON.parse(stderr);
+    assert.equal(parsed.ok, false);
+    assert.ok(parsed.error.includes("Unknown metric"));
+    assert.ok(parsed.error.includes("weight"));
+  });
+
+  it("streak with invalid metric fails with valid streak list", () => {
+    const { stderr, exitCode } = run("streak", "bogus");
+    assert.equal(exitCode, 1);
+    const parsed = JSON.parse(stderr);
+    assert.equal(parsed.ok, false);
+    assert.ok(parsed.error.includes("Unknown streak"));
+    assert.ok(parsed.error.includes("alcohol-free"));
+  });
+
+  it("trend --days 0 fails with positive integer error", () => {
+    const { stderr, exitCode } = run("trend", "weight", "--days", "0");
+    assert.equal(exitCode, 1);
+    const parsed = JSON.parse(stderr);
+    assert.equal(parsed.ok, false);
+    assert.ok(parsed.error.includes("positive integer"));
+  });
+
+  it("trend --days 3.5 fails with positive integer error", () => {
+    const { stderr, exitCode } = run("trend", "weight", "--days", "3.5");
+    assert.equal(exitCode, 1);
+    const parsed = JSON.parse(stderr);
+    assert.equal(parsed.ok, false);
+    assert.ok(parsed.error.includes("positive integer"));
+  });
+
+  it("trend --days abc fails with parse error", () => {
+    const { stderr, exitCode } = run("trend", "weight", "--days", "abc");
+    assert.equal(exitCode, 1);
+    const parsed = JSON.parse(stderr);
+    assert.equal(parsed.ok, false);
+    assert.ok(parsed.error.includes("not a number"));
   });
 
   // parseNum validation


### PR DESCRIPTION
## Summary
- Wire up `today`, `week`, `trend`, `streak`, and `status` commands to read from Supabase with proper aggregation
- Extract shared date helpers (`todayDate`, `daysAgo`) into `cli/src/lib/date.ts`
- Config-driven trend (11 metrics) and streak (4 types) implementations
- Supabase errors properly propagated, date-range filtering for multi-row tables
- 17 CLI tests passing, ROADMAP and README updated

## Test plan
- [x] `npm run build` compiles cleanly
- [x] `npm test` — 17 tests pass (validation, help text, error cases)
- [x] `ironcompass today` / `today --date 2026-03-05` — returns full day summary
- [x] `ironcompass week` — returns 7-day aggregation
- [x] `ironcompass trend weight --days 30` — returns trend points + summary
- [x] `ironcompass streak alcohol-free` — returns streak count
- [x] `ironcompass status` — returns combined dashboard JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)