### PR TITLE
Add generic custom metrics (#30)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,11 @@ Web Dashboard (read-only visualization)
 - date, body_fat_pct, muscle_mass_lbs, bone_mass_lbs, body_water_pct, visceral_fat, bmr, notes
 - Source: Hume Body Pod (via Apple Health sync or manual entry)
 
+### Custom Metrics
+- id (UUID), date, metric_name, value, unit, notes
+- EAV-style table for ad-hoc numeric metrics (coffee cups, water intake, mood, etc.)
+- Multiple entries per day per metric; metric_name lowercased at app layer
+
 ## CLI Commands
 
 ```bash
@@ -84,11 +89,16 @@ ironcompass log supplements --taken "vitamin-d,magnesium,omega-3,creatine"
 # Body composition
 ironcompass log bodycomp --fat 22.3 --muscle 145 --bone 7.2 --water 55.1 --visceral 8 --bmr 1680
 
+# Custom metrics
+ironcompass log metric --name coffee --value 1 --unit cups
+ironcompass log metric --name water --value 500 --unit ml
+
 # Queries
 ironcompass today                    # today's full summary
 ironcompass week                     # weekly summary
 ironcompass trend weight --days 30   # 30-day weight trend
 ironcompass trend sleep --days 14    # sleep trend
+ironcompass trend coffee --days 7    # custom metric trend
 ironcompass streak alcohol-free      # current alcohol-free streak
 ironcompass streak fasting           # fasting compliance streak
 ironcompass status                   # overall dashboard summary (for daily briefing)
@@ -106,6 +116,8 @@ The MCP server exposes these as tools Claude can call directly:
 - `ironcompass_log_bp` — log blood pressure
 - `ironcompass_log_supplements` — log supplements taken
 - `ironcompass_log_bodycomp` — log body composition (Hume Body Pod)
+- `ironcompass_log_metric` — log a custom numeric metric
+- `ironcompass_delete_metric` — delete a custom metric entry by ID
 - `ironcompass_query_today` — get today's summary
 - `ironcompass_query_week` — get weekly summary
 - `ironcompass_query_trend` — get trend data for a metric

--- a/cli/src/commands/log.ts
+++ b/cli/src/commands/log.ts
@@ -58,6 +58,11 @@ export async function logBodycomp(date: string, fields: { body_fat_pct?: number;
   return upsertRow("body_composition", { date, ...sparse(fields) });
 }
 
+export async function logMetric(date: string, metric_name: string, value: number, fields: { unit?: string; notes?: string } = {}) {
+  await ensureDailyEntry(date);
+  return insertRow("custom_metrics", { date, metric_name: metric_name.toLowerCase(), value, ...sparse(fields) });
+}
+
 export function registerLogCommands(program: Command): void {
   const today = todayDate();
   const log = program
@@ -272,6 +277,25 @@ export function registerLogCommands(program: Command): void {
           body_water_pct: parseNum("water", opts.water),
           visceral_fat: parseNum("visceral", opts.visceral),
           bmr: parseNum("bmr", opts.bmr),
+          notes: opts.notes as string | undefined,
+        });
+        success(result);
+      } catch (e: any) { fail(e.message ?? String(e)); }
+    });
+
+  // --- metric ---
+  log
+    .command("metric")
+    .description("Log a custom metric")
+    .option("--date <date>", "Date (YYYY-MM-DD)", today)
+    .requiredOption("--name <name>", "Metric name (e.g. coffee, water)")
+    .requiredOption("--value <number>", "Numeric value")
+    .option("--unit <unit>", "Unit (e.g. cups, ml)")
+    .option("--notes <text>", "Notes")
+    .action(async (opts) => {
+      try {
+        const result = await logMetric(opts.date as string, opts.name as string, parseNum("value", opts.value)!, {
+          unit: opts.unit as string | undefined,
           notes: opts.notes as string | undefined,
         });
         success(result);

--- a/cli/src/commands/query.ts
+++ b/cli/src/commands/query.ts
@@ -22,9 +22,10 @@ export async function fetchDay(date: string) {
     sb.from("pullups").select().eq("date", date).maybeSingle(),
     sb.from("supplements").select().eq("date", date).maybeSingle(),
     sb.from("body_composition").select().eq("date", date).maybeSingle(),
+    sb.from("custom_metrics").select().eq("date", date),
   ]);
   results.forEach(throwIfError);
-  const [daily, sleep, fasting, bp, workouts, meals, pullups, supplements, bodycomp] = results;
+  const [daily, sleep, fasting, bp, workouts, meals, pullups, supplements, bodycomp, customMetrics] = results;
 
   return {
     date,
@@ -38,6 +39,7 @@ export async function fetchDay(date: string) {
     pullups: pullups.data ?? null,
     supplements: supplements.data ?? null,
     body_composition: bodycomp.data ?? null,
+    custom_metrics: customMetrics.data ?? [],
   };
 }
 
@@ -60,9 +62,10 @@ export async function fetchWeek() {
     sb.from("meals").select().gte("date", start).lte("date", end).order("date"),
     sb.from("fasting").select().gte("date", start).lte("date", end).order("date"),
     sb.from("pullups").select().gte("date", start).lte("date", end).order("date"),
+    sb.from("custom_metrics").select().gte("date", start).lte("date", end).order("date"),
   ]);
   results.forEach(throwIfError);
-  const [daily, sleep, workouts, meals, fasting, pullups] = results;
+  const [daily, sleep, workouts, meals, fasting, pullups, customMetrics] = results;
 
   const dailyRows = daily.data ?? [];
   const sleepRows = sleep.data ?? [];
@@ -70,6 +73,7 @@ export async function fetchWeek() {
   const mealRows = meals.data ?? [];
   const fastingRows = fasting.data ?? [];
   const pullupRows = pullups.data ?? [];
+  const customMetricRows = customMetrics.data ?? [];
 
   // Weight delta
   const weights = dailyRows
@@ -111,6 +115,22 @@ export async function fetchWeek() {
   // Pullups
   const pullupTotal = pullupRows.reduce((s: number, r: any) => s + (r.total_count ?? 0), 0);
 
+  // Custom metrics: group by name, sum values per day, average across days
+  const customByName: Record<string, { total: number; dates: Set<string>; unit: string | null }> = {};
+  for (const r of customMetricRows as any[]) {
+    const entry = customByName[r.metric_name] ??= { total: 0, dates: new Set(), unit: null };
+    entry.total += Number(r.value);
+    entry.dates.add(r.date);
+    entry.unit ??= r.unit;
+  }
+  const customMetricsSummary: Record<string, { daily_avg: number | null; total: number; days: number; unit: string | null }> = {};
+  for (const [name, { total, dates, unit }] of Object.entries(customByName)) {
+    customMetricsSummary[name] = {
+      daily_avg: dates.size > 0 ? total / dates.size : null,
+      total, days: dates.size, unit,
+    };
+  }
+
   return {
     start,
     end,
@@ -148,6 +168,7 @@ export async function fetchWeek() {
       total: pullupTotal,
       days: pullupRows.length,
     },
+    custom_metrics: customMetricsSummary,
   };
 }
 
@@ -191,6 +212,16 @@ function singleSummary(values: number[]) {
   };
 }
 
+function dailySumPoints(rows: any[], col: string = "value"): Array<{ date: string; value: number }> {
+  const byDate: Record<string, number> = {};
+  for (const r of rows) {
+    if (r[col] != null) byDate[r.date] = (byDate[r.date] ?? 0) + Number(r[col]);
+  }
+  return Object.entries(byDate)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, value]) => ({ date, value }));
+}
+
 function multiSummaries(columns: string[], points: any[]) {
   const summaries: Record<string, any> = {};
   for (const col of columns) {
@@ -200,12 +231,38 @@ function multiSummaries(columns: string[], points: any[]) {
   return summaries;
 }
 
+async function computeCustomMetricTrend(metric: string, days: number) {
+  const start = daysAgo(days - 1);
+  const end = todayDate();
+  const sb = getSupabase();
+
+  const { data: rows, error } = await sb
+    .from("custom_metrics")
+    .select("date, value, unit")
+    .eq("metric_name", metric.toLowerCase())
+    .gte("date", start)
+    .lte("date", end)
+    .order("date", { ascending: true });
+
+  if (error) throw new Error(`Query failed: ${error.message}`);
+  const data = rows ?? [];
+  const points = dailySumPoints(data);
+  const unit = (data as any[]).find((r) => r.unit != null)?.unit ?? null;
+
+  return {
+    metric, days, start, end, unit, points,
+    summary: singleSummary(points.map((p) => p.value)),
+  };
+}
+
 export async function computeTrend(metric: string, days: number) {
-  if (!VALID_METRICS.includes(metric as MetricName)) {
-    throw new Error(`Unknown metric "${metric}". Valid metrics: ${VALID_METRICS.join(", ")}`);
-  }
   if (!Number.isInteger(days) || days <= 0) {
     throw new Error(`--days must be a positive integer, got "${days}"`);
+  }
+
+  // Fall back to custom_metrics if not a built-in metric
+  if (!VALID_METRICS.includes(metric as MetricName)) {
+    return computeCustomMetricTrend(metric, days);
   }
 
   const cfg = METRIC_MAP[metric as MetricName];
@@ -266,16 +323,7 @@ export async function computeTrend(metric: string, days: number) {
   }
 
   // daily-sum
-  const col = cfg.columns[0];
-  const byDate: Record<string, number> = {};
-  for (const r of data as any[]) {
-    if (r[col] != null) {
-      byDate[r.date] = (byDate[r.date] ?? 0) + r[col];
-    }
-  }
-  const points = Object.entries(byDate)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([date, value]) => ({ date, value }));
+  const points = dailySumPoints(data, cfg.columns[0]);
   return {
     metric, days, start, end, points,
     summary: singleSummary(points.map((p) => p.value)),
@@ -368,7 +416,7 @@ export function registerQueryCommands(program: Command): void {
   program
     .command("trend")
     .description("Trend data for a metric")
-    .argument("<metric>", `Metric to trend (${VALID_METRICS.join(", ")})`)
+    .argument("<metric>", `Metric to trend (${VALID_METRICS.join(", ")}, or any custom metric name)`)
     .option("--days <n>", "Number of days", "30")
     .action(async (metric, opts) => {
       try {

--- a/cli/src/mcp.ts
+++ b/cli/src/mcp.ts
@@ -3,7 +3,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { fetchDay, fetchWeek, computeTrend, computeStreak, VALID_METRICS, VALID_STREAKS } from "./commands/query.js";
-import { logDaily, logSleep, logFasting, logBp, logWorkout, logMeal, logPullups, logSupplements, logBodycomp, WORKOUT_TYPES } from "./commands/log.js";
+import { logDaily, logSleep, logFasting, logBp, logWorkout, logMeal, logPullups, logSupplements, logBodycomp, logMetric, WORKOUT_TYPES } from "./commands/log.js";
 import { deleteRowById } from "./db.js";
 import { todayDate } from "./lib/date.js";
 import { dayUrl, calendarUrl } from "./lib/urls.js";
@@ -42,7 +42,7 @@ server.registerTool("ironcompass_query_trend", {
   title: "Metric Trend",
   description: "Get trend data for a health metric over time",
   inputSchema: z.object({
-    metric: z.enum(VALID_METRICS).describe("Metric to trend"),
+    metric: z.string().describe(`Metric to trend. Built-in: ${VALID_METRICS.join(", ")}. Also accepts any custom metric name.`),
     days: z.number().optional().describe("Number of days (default 30)"),
   }),
 }, async ({ metric, days }) => {
@@ -209,7 +209,33 @@ server.registerTool("ironcompass_log_bodycomp", {
   return logResult(d, await logBodycomp(d, fields));
 });
 
+server.registerTool("ironcompass_log_metric", {
+  title: "Log Custom Metric",
+  description: "Log a custom numeric metric (e.g. coffee cups, water intake, mood score)",
+  inputSchema: z.object({
+    date: optDate,
+    name: z.string().describe("Metric name (e.g. coffee, water, mood)"),
+    value: z.number().describe("Numeric value"),
+    unit: z.string().optional().describe("Unit (e.g. cups, ml, score)"),
+    notes: z.string().optional(),
+  }),
+}, async ({ date, name, value, unit, notes }) => {
+  const d = date ?? todayDate();
+  return logResult(d, await logMetric(d, name, value, { unit, notes }));
+});
+
 // --- Delete tools ---
+
+server.registerTool("ironcompass_delete_metric", {
+  title: "Delete Custom Metric",
+  description: "Delete a custom metric entry by its ID",
+  inputSchema: z.object({
+    id: z.string().uuid().describe("Custom metric UUID to delete"),
+  }),
+}, async ({ id }) => {
+  const deleted = await deleteRowById("custom_metrics", id);
+  return textResult({ deleted, dashboard_url: dayUrl(deleted.date) });
+});
 
 server.registerTool("ironcompass_delete_workout", {
   title: "Delete Workout",

--- a/cli/src/types/database.ts
+++ b/cli/src/types/database.ts
@@ -14,6 +14,47 @@ export type Database = {
   }
   public: {
     Tables: {
+      custom_metrics: {
+        Row: {
+          created_at: string | null
+          date: string
+          id: string
+          metric_name: string
+          notes: string | null
+          unit: string | null
+          updated_at: string | null
+          value: number
+        }
+        Insert: {
+          created_at?: string | null
+          date: string
+          id?: string
+          metric_name: string
+          notes?: string | null
+          unit?: string | null
+          updated_at?: string | null
+          value: number
+        }
+        Update: {
+          created_at?: string | null
+          date?: string
+          id?: string
+          metric_name?: string
+          notes?: string | null
+          unit?: string | null
+          updated_at?: string | null
+          value?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "custom_metrics_date_fkey"
+            columns: ["date"]
+            isOneToOne: false
+            referencedRelation: "daily_entries"
+            referencedColumns: ["date"]
+          },
+        ]
+      }
       blood_pressure: {
         Row: {
           created_at: string | null

--- a/src/components/day-detail/day-detail.tsx
+++ b/src/components/day-detail/day-detail.tsx
@@ -12,6 +12,7 @@ import SectionMeals from "./section-meals";
 import SectionPullups from "./section-pullups";
 import SectionSupplements from "./section-supplements";
 import SectionBodyComp from "./section-body-comp";
+import SectionCustomMetrics from "./section-custom-metrics";
 
 export default function DayDetail({ date, backMonth }: { date: string; backMonth?: string }) {
   const [data, setData] = useState<DayData | null>(null);
@@ -72,6 +73,9 @@ export default function DayDetail({ date, backMonth }: { date: string; backMonth
         <div className="col-span-full">
           <SectionBodyComp data={data!.bodyComp} />
         </div>
+        <div className="col-span-full">
+          <SectionCustomMetrics data={data!.customMetrics} />
+        </div>
       </div>
     </div>
   );
@@ -82,10 +86,10 @@ function LoadingSkeleton({ date, backMonth }: { date: string; backMonth?: string
     <div>
       <DayHeader date={date} backMonth={backMonth} />
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-        {Array.from({ length: 9 }).map((_, i) => (
+        {Array.from({ length: 10 }).map((_, i) => (
           <div
             key={i}
-            className={`skeleton rounded-lg h-32 ${[4, 5, 8].includes(i) ? "col-span-full" : ""}`}
+            className={`skeleton rounded-lg h-32 ${[4, 5, 8, 9].includes(i) ? "col-span-full" : ""}`}
             style={{ animationDelay: `${i * 50}ms` }}
           />
         ))}

--- a/src/components/day-detail/section-custom-metrics.tsx
+++ b/src/components/day-detail/section-custom-metrics.tsx
@@ -1,0 +1,53 @@
+import type { CustomMetricRow } from "@/lib/types";
+import SectionCard from "./section-card";
+
+function capitalize(s: string) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+export default function SectionCustomMetrics({ data }: { data: CustomMetricRow[] }) {
+  if (data.length === 0) return null;
+
+  // Group by metric_name
+  const grouped = new Map<string, CustomMetricRow[]>();
+  for (const row of data) {
+    if (!grouped.has(row.metric_name)) grouped.set(row.metric_name, []);
+    grouped.get(row.metric_name)!.push(row);
+  }
+
+  return (
+    <SectionCard title="Custom Metrics" accent="#8b5cf6">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+        {[...grouped.entries()].map(([name, rows]) => {
+          const total = rows.reduce((s, r) => s + r.value, 0);
+          const unit = rows[0].unit;
+          const notes = rows.map((r) => r.notes).filter(Boolean);
+
+          return (
+            <div key={name}>
+              <p className="text-[11px] font-mono text-muted uppercase tracking-wider mb-1">
+                {capitalize(name)}
+              </p>
+              <p className="text-lg font-semibold text-foreground tabular-nums">
+                {rows.length > 1 ? (
+                  <>
+                    <span className="text-sm text-muted font-normal">
+                      {rows.map((r) => r.value).join(" + ")} ={" "}
+                    </span>
+                    {total}
+                  </>
+                ) : (
+                  total
+                )}
+                {unit && <span className="text-sm text-muted font-normal ml-1">{unit}</span>}
+              </p>
+              {notes.length > 0 && (
+                <p className="text-xs text-muted mt-0.5">{notes.join("; ")}</p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -2,6 +2,7 @@ import { supabase } from "./supabase";
 import type {
   BloodPressureRow,
   BodyCompositionRow,
+  CustomMetricRow,
   DailyEntryRow,
   FastingRow,
   MealRow,
@@ -21,6 +22,7 @@ export interface DayData {
   pullups: PullupsRow | null;
   supplements: SupplementsRow | null;
   bodyComp: BodyCompositionRow | null;
+  customMetrics: CustomMetricRow[];
 }
 
 export async function fetchDayData(date: string): Promise<DayData> {
@@ -34,6 +36,7 @@ export async function fetchDayData(date: string): Promise<DayData> {
     pullupsRes,
     supplementsRes,
     bodyCompRes,
+    customMetricsRes,
   ] = await Promise.all([
     supabase.from("daily_entries").select("*").eq("date", date).maybeSingle(),
     supabase.from("sleep").select("*").eq("date", date).maybeSingle(),
@@ -44,11 +47,12 @@ export async function fetchDayData(date: string): Promise<DayData> {
     supabase.from("pullups").select("*").eq("date", date).maybeSingle(),
     supabase.from("supplements").select("*").eq("date", date).maybeSingle(),
     supabase.from("body_composition").select("*").eq("date", date).maybeSingle(),
+    supabase.from("custom_metrics").select("*").eq("date", date).order("metric_name").order("created_at"),
   ]);
 
   const errors = [
     dailyRes, sleepRes, fastingRes, workoutsRes, mealsRes,
-    bpRes, pullupsRes, supplementsRes, bodyCompRes,
+    bpRes, pullupsRes, supplementsRes, bodyCompRes, customMetricsRes,
   ]
     .filter((r) => r.error)
     .map((r) => r.error!.message);
@@ -67,5 +71,6 @@ export async function fetchDayData(date: string): Promise<DayData> {
     pullups: pullupsRes.data,
     supplements: supplementsRes.data,
     bodyComp: bodyCompRes.data,
+    customMetrics: customMetricsRes.data ?? [],
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,6 +9,18 @@ export type Json =
 export type Database = {
   public: {
     Tables: {
+      custom_metrics: {
+        Row: {
+          created_at: string | null
+          date: string
+          id: string
+          metric_name: string
+          notes: string | null
+          unit: string | null
+          updated_at: string | null
+          value: number
+        }
+      }
       blood_pressure: {
         Row: {
           created_at: string | null
@@ -140,6 +152,7 @@ export type WorkoutType =
 
 export type ViewType = "calendar" | "daily";
 
+export type CustomMetricRow = Database["public"]["Tables"]["custom_metrics"]["Row"];
 export type BloodPressureRow = Database["public"]["Tables"]["blood_pressure"]["Row"];
 export type BodyCompositionRow = Database["public"]["Tables"]["body_composition"]["Row"];
 export type DailyEntryRow = Database["public"]["Tables"]["daily_entries"]["Row"];

--- a/supabase/migrations/006_custom_metrics.sql
+++ b/supabase/migrations/006_custom_metrics.sql
@@ -1,0 +1,20 @@
+create table custom_metrics (
+  id uuid primary key default gen_random_uuid(),
+  date date not null references daily_entries(date) on delete cascade,
+  metric_name text not null check (length(metric_name) > 0),
+  value decimal(10,2) not null,
+  unit text,
+  notes text,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create index idx_custom_metrics_date on custom_metrics(date);
+create index idx_custom_metrics_name_date on custom_metrics(metric_name, date);
+
+create trigger set_updated_at before update on custom_metrics
+  for each row execute function update_updated_at();
+
+alter table custom_metrics enable row level security;
+create policy "anon_read" on custom_metrics for select to anon using (true);
+create policy "service_all" on custom_metrics for all to service_role using (true) with check (true);


### PR DESCRIPTION
## Summary
- Adds `custom_metrics` EAV-style table for tracking ad-hoc numeric metrics (coffee, water, mood, etc.)
- Full CLI (`ironcompass log metric`), MCP (`ironcompass_log_metric`, `ironcompass_delete_metric`), and query support
- Dashboard section with grouping by metric name, value summation breakdown, and violet accent
- `ironcompass trend <name>` now accepts any custom metric name as fallback

## Test plan
- [x] Migration applied to Supabase
- [x] CLI build passes
- [x] `ironcompass log metric --name coffee --value 1 --unit cups` works
- [x] `ironcompass today` includes custom_metrics array
- [x] `ironcompass week` includes grouped custom_metrics summary
- [x] `ironcompass trend coffee --days 7` works via custom metric fallback
- [x] Built-in `ironcompass trend protein --days 7` still works (daily-sum refactor)
- [x] Playwright screenshot confirms dashboard rendering

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)