### PR TITLE
Add metrics dashboard with sparkline charts and trend queries (#14)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Expose IronCompass as MCP tools so Claude can call them directly from LifeOS ses
 | #9 | Query tools (all `ironcompass_query_*` tools) | **done** |
 | #10 | Register MCP server in LifeOS Claude config | **done** |
 | #27 | Set up local Supabase test environment with seed data | todo |
-| #30 | Generic custom metrics table + `ironcompass_log_metric` tool (coffee, water, etc.) | todo |
+| #30 | Generic custom metrics table + `ironcompass_log_metric` tool (coffee, water, etc.) | **done** |
 
 ## Phase 3: Web Dashboard — #11
 
@@ -58,6 +58,15 @@ All dashboard views (monthly calendar, weekly, daily) share a single page with `
 Source integrations (Apple Health, Oura, Hevy, Strava) live in LifeOS, not IronCompass. LifeOS reconciles data from multiple sources before sending it here via MCP tools. Issues #18-22 closed — moved to LifeOS.
 
 ---
+
+## Schema Enhancements
+
+| Issue | Task | Status |
+|---|---|---|
+| #32 | Add `start_time` and `end_time` to workouts (dedup, HR correlation, chronological display) | todo |
+| #33 | Add `source` field to workouts (dedup, data quality, reconciliation) | todo |
+| #34 | Add `indoor_cycle` workout type | todo |
+| #35 | Add `details` JSONB column to workouts for type-specific data (strength sets, golf scores, etc.) | todo |
 
 ## Future Ideas
 - Apple Shortcuts for quick logging from iPhone

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Shell from "@/components/layout/shell";
 import Calendar from "@/components/calendar/calendar";
 import DayDetail from "@/components/day-detail/day-detail";
+import MetricsDashboard from "@/components/metrics/metrics-dashboard";
 import type { ViewType } from "@/lib/types";
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
@@ -22,11 +23,15 @@ export default async function Home({
   const date = params.date && isValidDate(params.date) ? params.date : undefined;
   const month = params.month && isValidDate(params.month) ? params.month : undefined;
 
-  const currentView: ViewType = view === "daily" ? "daily" : "calendar";
+  const currentView: ViewType =
+    view === "metrics" ? "metrics" :
+    view === "daily" ? "daily" : "calendar";
 
   return (
     <Shell currentView={currentView}>
-      {currentView === "daily" && date ? (
+      {currentView === "metrics" ? (
+        <MetricsDashboard />
+      ) : currentView === "daily" && date ? (
         <DayDetail date={date} backMonth={month} />
       ) : (
         <Calendar initialMonth={month} />

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -1,4 +1,10 @@
+import Link from "next/link";
 import type { ViewType } from "@/lib/types";
+
+const NAV_ITEMS: { label: string; href: string; views: ViewType[] }[] = [
+  { label: "Calendar", href: "/", views: ["calendar", "daily"] },
+  { label: "Metrics", href: "/?view=metrics", views: ["metrics"] },
+];
 
 export default function Shell({ children, currentView = "calendar" }: { children: React.ReactNode; currentView?: ViewType }) {
   return (
@@ -13,16 +19,22 @@ export default function Shell({ children, currentView = "calendar" }: { children
           </div>
 
           <nav className="flex items-center gap-1">
-            <span className={`px-3 py-1.5 text-xs font-mono tracking-wider uppercase rounded ${
-              currentView === "calendar" || currentView === "daily"
-                ? "font-medium text-accent border border-accent/30 bg-accent/5"
-                : "text-muted cursor-not-allowed"
-            }`}>
-              Calendar
-            </span>
-            <span className="px-3 py-1.5 text-xs font-mono tracking-wider uppercase text-muted cursor-not-allowed">
-              Metrics
-            </span>
+            {NAV_ITEMS.map((item) => {
+              const active = item.views.includes(currentView);
+              return (
+                <Link
+                  key={item.label}
+                  href={item.href}
+                  className={`px-3 py-1.5 text-xs font-mono tracking-wider uppercase rounded transition-colors ${
+                    active
+                      ? "font-medium text-accent border border-accent/30 bg-accent/5"
+                      : "text-muted hover:text-foreground hover:bg-surface-hover"
+                  }`}
+                >
+                  {item.label}
+                </Link>
+              );
+            })}
             <span className="px-3 py-1.5 text-xs font-mono tracking-wider uppercase text-muted cursor-not-allowed">
               Weekly
             </span>

--- a/src/components/metrics/bp-card.tsx
+++ b/src/components/metrics/bp-card.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useMemo } from "react";
+import SectionCard from "@/components/day-detail/section-card";
+import { Stat } from "@/components/day-detail/section-vitals";
+import Sparkline from "./sparkline";
+import { formatNumber } from "@/lib/format";
+import type { TrendSummary } from "@/lib/queries";
+
+interface BPPoint {
+  date: string;
+  systolic: number | null;
+  diastolic: number | null;
+}
+
+interface BPCardProps {
+  points: BPPoint[];
+  summaries: Record<string, TrendSummary>;
+}
+
+export default function BPCard({ points, summaries }: BPCardProps) {
+  const empty = points.length === 0;
+
+  const sysPoints = useMemo(
+    () => points.filter((p) => p.systolic != null).map((p) => ({ date: p.date, value: p.systolic! })),
+    [points],
+  );
+
+  const diaPoints = useMemo(
+    () => points.filter((p) => p.diastolic != null).map((p) => ({ date: p.date, value: p.diastolic! })),
+    [points],
+  );
+
+  return (
+    <SectionCard title="Blood Pressure" accent="#ef4444" empty={empty}>
+      {!empty && (
+        <>
+          <div className="h-20 mb-3 relative">
+            {sysPoints.length > 0 && (
+              <div className="absolute inset-0">
+                <Sparkline points={sysPoints} color="#ef4444" fill={false} />
+              </div>
+            )}
+            {diaPoints.length > 0 && (
+              <div className="absolute inset-0">
+                <Sparkline points={diaPoints} color="#3b82f6" fill={false} />
+              </div>
+            )}
+          </div>
+          <div className="flex gap-3 mb-2">
+            <div className="flex items-center gap-1.5">
+              <div className="w-2 h-0.5 bg-[#ef4444] rounded" />
+              <span className="text-[10px] font-mono text-muted">Systolic</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <div className="w-2 h-0.5 bg-[#3b82f6] rounded" />
+              <span className="text-[10px] font-mono text-muted">Diastolic</span>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <Stat label="Avg Systolic" value={formatNumber(summaries.systolic?.avg ?? null, 0)} unit="mmHg" />
+            <Stat label="Avg Diastolic" value={formatNumber(summaries.diastolic?.avg ?? null, 0)} unit="mmHg" />
+          </div>
+        </>
+      )}
+    </SectionCard>
+  );
+}

--- a/src/components/metrics/metric-card.tsx
+++ b/src/components/metrics/metric-card.tsx
@@ -1,0 +1,55 @@
+import SectionCard from "@/components/day-detail/section-card";
+import { Stat } from "@/components/day-detail/section-vitals";
+import Sparkline from "./sparkline";
+import { formatNumber } from "@/lib/format";
+import type { TrendSummary } from "@/lib/queries";
+
+interface MetricCardProps {
+  title: string;
+  accent: string;
+  points: Array<{ date: string; value: number }>;
+  summary: TrendSummary;
+  unit?: string;
+  goalLine?: number;
+  goalLabel?: string;
+}
+
+export default function MetricCard({
+  title,
+  accent,
+  points,
+  summary,
+  unit,
+  goalLine,
+  goalLabel,
+}: MetricCardProps) {
+  const empty = points.length === 0;
+
+  return (
+    <SectionCard title={title} accent={accent} empty={empty}>
+      {!empty && (
+        <>
+          <div className="h-20 mb-3">
+            <Sparkline
+              points={points}
+              color={accent}
+              goalLine={goalLine}
+              goalColor={goalLine != null ? `${accent}44` : undefined}
+            />
+          </div>
+          <div className="grid grid-cols-4 gap-2">
+            <Stat label="Current" value={formatNumber(points[points.length - 1].value)} unit={unit} />
+            <Stat label="Avg" value={formatNumber(summary.avg)} unit={unit} />
+            <Stat label="Min" value={formatNumber(summary.min)} unit={unit} />
+            <Stat label="Max" value={formatNumber(summary.max)} unit={unit} />
+          </div>
+          {goalLabel && goalLine != null && (
+            <p className="text-[10px] font-mono text-muted mt-2">
+              Goal: {goalLine}{unit ? ` ${unit}` : ""} ({goalLabel})
+            </p>
+          )}
+        </>
+      )}
+    </SectionCard>
+  );
+}

--- a/src/components/metrics/metrics-dashboard.tsx
+++ b/src/components/metrics/metrics-dashboard.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  fetchTrend,
+  fetchStreak,
+  EMPTY_TREND_SUMMARY,
+  type TrendResult,
+  type SingleTrendResult,
+  type MultiTrendResult,
+  type StreakResult,
+} from "@/lib/queries";
+import { WEIGHT_GOAL, PROTEIN_TARGET } from "@/lib/config";
+import RangeSelector from "./range-selector";
+import MetricCard from "./metric-card";
+import SleepCard from "./sleep-card";
+import BPCard from "./bp-card";
+import StreakCard from "./streak-card";
+
+interface SleepCardPoint { date: string; oura_score: number | null; apple_score: number | null; hours: number | null }
+interface BPCardPoint { date: string; systolic: number | null; diastolic: number | null }
+
+function isSingle(t: TrendResult): t is SingleTrendResult {
+  return "summary" in t;
+}
+
+function isMulti(t: TrendResult): t is MultiTrendResult {
+  return "summaries" in t;
+}
+
+interface Trends {
+  weight: TrendResult | null;
+  sleep: TrendResult | null;
+  pullups: TrendResult | null;
+  bp: TrendResult | null;
+  protein: TrendResult | null;
+}
+
+interface Streaks {
+  alcoholFree: StreakResult | null;
+  fasting: StreakResult | null;
+}
+
+function countFailed(results: PromiseSettledResult<unknown>[]): number {
+  return results.filter((r) => r.status === "rejected").length;
+}
+
+export default function MetricsDashboard() {
+  const [days, setDays] = useState(30);
+  const [trends, setTrends] = useState<Trends | null>(null);
+  const [trendsDays, setTrendsDays] = useState<number | null>(null);
+  const [streaks, setStreaks] = useState<Streaks | null>(null);
+  const [failedCount, setFailedCount] = useState(0);
+
+  const loading = trends === null || trendsDays !== days;
+
+  // Fetch streaks once on mount
+  useEffect(() => {
+    const controller = new AbortController();
+
+    Promise.allSettled([
+      fetchStreak("alcohol-free"),
+      fetchStreak("fasting"),
+    ]).then((results) => {
+      if (controller.signal.aborted) return;
+      const [af, f] = results;
+      setStreaks({
+        alcoholFree: af.status === "fulfilled" ? af.value : null,
+        fasting: f.status === "fulfilled" ? f.value : null,
+      });
+      setFailedCount((prev) => prev + countFailed(results));
+    });
+
+    return () => controller.abort();
+  }, []);
+
+  const fetchTrends = useCallback((rangeDays: number) => {
+    const controller = new AbortController();
+
+    Promise.allSettled([
+      fetchTrend("weight", rangeDays),
+      fetchTrend("sleep", rangeDays),
+      fetchTrend("pullups", rangeDays),
+      fetchTrend("bp", rangeDays),
+      fetchTrend("protein", rangeDays),
+    ]).then((results) => {
+      if (controller.signal.aborted) return;
+      const [weight, sleep, pullups, bp, protein] = results;
+      setTrends({
+        weight: weight.status === "fulfilled" ? weight.value : null,
+        sleep: sleep.status === "fulfilled" ? sleep.value : null,
+        pullups: pullups.status === "fulfilled" ? pullups.value : null,
+        bp: bp.status === "fulfilled" ? bp.value : null,
+        protein: protein.status === "fulfilled" ? protein.value : null,
+      });
+      setTrendsDays(rangeDays);
+      setFailedCount(countFailed(results));
+    });
+
+    return controller;
+  }, []);
+
+  // Fetch trends when days changes
+  useEffect(() => {
+    const controller = fetchTrends(days);
+    return () => controller.abort();
+  }, [days, fetchTrends]);
+
+  if (loading && !trends) {
+    return (
+      <div>
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="font-mono text-sm font-bold tracking-[0.15em] uppercase text-foreground">
+            Metrics
+          </h2>
+          <RangeSelector value={days} onChange={setDays} />
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {Array.from({ length: 7 }).map((_, i) => (
+            <div
+              key={i}
+              className="skeleton rounded-lg h-40"
+              style={{ animationDelay: `${i * 50}ms` }}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const weightData = trends?.weight && isSingle(trends.weight) ? trends.weight : null;
+  const sleepData = trends?.sleep && isMulti(trends.sleep) ? trends.sleep : null;
+  const pullupsData = trends?.pullups && isSingle(trends.pullups) ? trends.pullups : null;
+  const bpData = trends?.bp && isMulti(trends.bp) ? trends.bp : null;
+  const proteinData = trends?.protein && isSingle(trends.protein) ? trends.protein : null;
+
+  return (
+    <div className="animate-slide-in">
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="font-mono text-sm font-bold tracking-[0.15em] uppercase text-foreground">
+          Metrics
+        </h2>
+        <RangeSelector value={days} onChange={setDays} />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <MetricCard
+          title="Weight"
+          accent="#22c55e"
+          points={weightData?.points ?? []}
+          summary={weightData?.summary ?? EMPTY_TREND_SUMMARY}
+          unit="lbs"
+          goalLine={WEIGHT_GOAL}
+          goalLabel="Target"
+        />
+
+        <SleepCard
+          points={sleepData?.points as SleepCardPoint[] ?? []}
+          summaries={sleepData?.summaries ?? {}}
+        />
+
+        <StreakCard
+          title="Fasting Compliance"
+          accent="#f97316"
+          streak={streaks?.fasting?.current_streak ?? null}
+          startDate={streaks?.fasting?.start_date ?? null}
+          label="days compliant"
+        />
+        <StreakCard
+          title="Alcohol-Free"
+          accent="#06b6d4"
+          streak={streaks?.alcoholFree?.current_streak ?? null}
+          startDate={streaks?.alcoholFree?.start_date ?? null}
+          label="days sober"
+        />
+
+        <MetricCard
+          title="Pullups"
+          accent="#eab308"
+          points={pullupsData?.points ?? []}
+          summary={pullupsData?.summary ?? EMPTY_TREND_SUMMARY}
+        />
+
+        <BPCard
+          points={bpData?.points as BPCardPoint[] ?? []}
+          summaries={bpData?.summaries ?? {}}
+        />
+
+        <div className="md:col-span-2">
+          <MetricCard
+            title="Protein"
+            accent="#3b82f6"
+            points={proteinData?.points ?? []}
+            summary={proteinData?.summary ?? EMPTY_TREND_SUMMARY}
+            unit="g"
+            goalLine={PROTEIN_TARGET}
+            goalLabel="Daily target"
+          />
+        </div>
+      </div>
+
+      {failedCount > 0 && (
+        <div className="mt-3 px-3 py-2 rounded border border-amber-500/30 bg-amber-500/5 text-amber-400 text-xs font-mono">
+          {failedCount} metric{failedCount > 1 ? "s" : ""} failed to load
+        </div>
+      )}
+
+      {loading && (
+        <div className="mt-3 text-center">
+          <span className="text-xs font-mono text-muted animate-pulse">Updating...</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/metrics/range-selector.tsx
+++ b/src/components/metrics/range-selector.tsx
@@ -1,0 +1,26 @@
+const RANGES = [7, 14, 30, 90] as const;
+
+interface RangeSelectorProps {
+  value: number;
+  onChange: (days: number) => void;
+}
+
+export default function RangeSelector({ value, onChange }: RangeSelectorProps) {
+  return (
+    <div className="flex items-center gap-1">
+      {RANGES.map((days) => (
+        <button
+          key={days}
+          onClick={() => onChange(days)}
+          className={`px-3 py-1.5 text-xs font-mono tracking-wider uppercase rounded transition-colors ${
+            value === days
+              ? "font-medium text-accent border border-accent/30 bg-accent/5"
+              : "text-muted hover:text-foreground hover:bg-surface-hover"
+          }`}
+        >
+          {days}d
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/metrics/sleep-card.tsx
+++ b/src/components/metrics/sleep-card.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useMemo } from "react";
+import SectionCard from "@/components/day-detail/section-card";
+import { Stat } from "@/components/day-detail/section-vitals";
+import Sparkline from "./sparkline";
+import { formatNumber } from "@/lib/format";
+import type { TrendSummary } from "@/lib/queries";
+
+interface SleepPoint {
+  date: string;
+  oura_score: number | null;
+  apple_score: number | null;
+  hours: number | null;
+}
+
+interface SleepCardProps {
+  points: SleepPoint[];
+  summaries: Record<string, TrendSummary>;
+}
+
+export default function SleepCard({ points, summaries }: SleepCardProps) {
+  const empty = points.length === 0;
+
+  const ouraPoints = useMemo(
+    () => points.filter((p) => p.oura_score != null).map((p) => ({ date: p.date, value: p.oura_score! })),
+    [points],
+  );
+
+  const applePoints = useMemo(
+    () => points.filter((p) => p.apple_score != null).map((p) => ({ date: p.date, value: p.apple_score! })),
+    [points],
+  );
+
+  return (
+    <SectionCard title="Sleep" accent="#a855f7" empty={empty}>
+      {!empty && (
+        <>
+          <div className="h-20 mb-3 relative">
+            {ouraPoints.length > 0 && (
+              <div className="absolute inset-0">
+                <Sparkline points={ouraPoints} color="#a855f7" fill={false} />
+              </div>
+            )}
+            {applePoints.length > 0 && (
+              <div className="absolute inset-0">
+                <Sparkline points={applePoints} color="#3b82f6" fill={false} />
+              </div>
+            )}
+          </div>
+          <div className="flex gap-3 mb-2">
+            {ouraPoints.length > 0 && (
+              <div className="flex items-center gap-1.5">
+                <div className="w-2 h-0.5 bg-[#a855f7] rounded" />
+                <span className="text-[10px] font-mono text-muted">Oura</span>
+              </div>
+            )}
+            {applePoints.length > 0 && (
+              <div className="flex items-center gap-1.5">
+                <div className="w-2 h-0.5 bg-[#3b82f6] rounded" />
+                <span className="text-[10px] font-mono text-muted">Apple</span>
+              </div>
+            )}
+          </div>
+          <div className="grid grid-cols-3 gap-2">
+            <Stat label="Avg Oura" value={formatNumber(summaries.oura_score?.avg ?? null)} />
+            <Stat label="Avg Apple" value={formatNumber(summaries.apple_score?.avg ?? null)} />
+            <Stat label="Avg Hours" value={formatNumber(summaries.hours?.avg ?? null)} unit="h" />
+          </div>
+        </>
+      )}
+    </SectionCard>
+  );
+}

--- a/src/components/metrics/sparkline.tsx
+++ b/src/components/metrics/sparkline.tsx
@@ -1,0 +1,120 @@
+import { memo } from "react";
+
+interface SparklinePoint {
+  date: string;
+  value: number;
+}
+
+interface SparklineProps {
+  points: SparklinePoint[];
+  color: string;
+  width?: number;
+  height?: number;
+  goalLine?: number;
+  goalColor?: string;
+  fill?: boolean;
+}
+
+function SparklineInner({
+  points,
+  color,
+  width = 300,
+  height = 80,
+  goalLine,
+  goalColor = "#ffffff33",
+  fill = true,
+}: SparklineProps) {
+  if (points.length === 0) return null;
+
+  const pad = { top: 8, bottom: 8, left: 4, right: 4 };
+  const plotW = width - pad.left - pad.right;
+  const plotH = height - pad.top - pad.bottom;
+
+  // Compute y range including goal line
+  const values = points.map((p) => p.value);
+  if (goalLine != null) values.push(goalLine);
+  let yMin = Math.min(...values);
+  let yMax = Math.max(...values);
+
+  // Add 10% padding so lines don't touch edges
+  const yRange = yMax - yMin || 1;
+  yMin -= yRange * 0.1;
+  yMax += yRange * 0.1;
+
+  // Map dates to x positions proportional to actual time gaps
+  const times = points.map((p) => new Date(p.date + "T00:00:00").getTime());
+  const tMin = times[0];
+  const tMax = times[times.length - 1];
+  const tRange = tMax - tMin || 1;
+
+  function toX(t: number) {
+    return pad.left + ((t - tMin) / tRange) * plotW;
+  }
+
+  function toY(v: number) {
+    return pad.top + plotH - ((v - yMin) / (yMax - yMin)) * plotH;
+  }
+
+  const svgPoints = points.map((p, i) => ({
+    x: points.length === 1 ? pad.left + plotW / 2 : toX(times[i]),
+    y: toY(p.value),
+  }));
+
+  const lineD = svgPoints.map((p, i) => `${i === 0 ? "M" : "L"}${p.x},${p.y}`).join(" ");
+
+  const gradientId = `sparkfill-${color.replace("#", "")}`;
+
+  // Fill path: line + close along bottom
+  const fillD = points.length > 1
+    ? `${lineD} L${svgPoints[svgPoints.length - 1].x},${pad.top + plotH} L${svgPoints[0].x},${pad.top + plotH} Z`
+    : "";
+
+  const lastPt = svgPoints[svgPoints.length - 1];
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      width="100%"
+      height="100%"
+      preserveAspectRatio="none"
+      role="img"
+      aria-label="Sparkline chart"
+    >
+      <defs>
+        <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={color} stopOpacity="0.2" />
+          <stop offset="100%" stopColor={color} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+
+      {/* Fill area */}
+      {fill && fillD && (
+        <path d={fillD} fill={`url(#${gradientId})`} />
+      )}
+
+      {/* Goal line */}
+      {goalLine != null && (
+        <line
+          x1={pad.left}
+          y1={toY(goalLine)}
+          x2={pad.left + plotW}
+          y2={toY(goalLine)}
+          stroke={goalColor}
+          strokeWidth="1"
+          strokeDasharray="4 3"
+        />
+      )}
+
+      {/* Line */}
+      {points.length > 1 && (
+        <path d={lineD} fill="none" stroke={color} strokeWidth="1.5" strokeLinejoin="round" />
+      )}
+
+      {/* Last point dot */}
+      <circle cx={lastPt.x} cy={lastPt.y} r="2.5" fill={color} />
+    </svg>
+  );
+}
+
+const Sparkline = memo(SparklineInner);
+export default Sparkline;

--- a/src/components/metrics/streak-card.tsx
+++ b/src/components/metrics/streak-card.tsx
@@ -1,0 +1,32 @@
+import SectionCard from "@/components/day-detail/section-card";
+
+interface StreakCardProps {
+  title: string;
+  accent: string;
+  streak: number | null;
+  startDate: string | null;
+  label: string;
+}
+
+export default function StreakCard({ title, accent, streak, startDate, label }: StreakCardProps) {
+  return (
+    <SectionCard title={title} accent={accent} empty={streak === null}>
+      {streak !== null && (
+        <div className="flex items-center gap-4">
+          <div
+            className="text-4xl font-mono font-bold tabular-nums"
+            style={{ color: accent, textShadow: `0 0 20px ${accent}44` }}
+          >
+            {streak}
+          </div>
+          <div>
+            <p className="text-xs font-mono text-foreground">{label}</p>
+            {startDate && (
+              <p className="text-[10px] font-mono text-muted mt-0.5">Since {startDate}</p>
+            )}
+          </div>
+        </div>
+      )}
+    </SectionCard>
+  );
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,2 @@
+export const WEIGHT_GOAL = 165;
+export const PROTEIN_TARGET = 150;

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,4 @@
+export function formatNumber(v: number | null, decimals = 1): string | null {
+  if (v == null) return null;
+  return Number(v.toFixed(decimals)).toString();
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,4 +1,5 @@
 import { supabase } from "./supabase";
+import { formatDate, addDays } from "./date";
 import type {
   BloodPressureRow,
   BodyCompositionRow,
@@ -11,6 +12,8 @@ import type {
   SupplementsRow,
   WorkoutRow,
 } from "./types";
+
+// ─── Day Data ────────────────────────────────────────────
 
 export interface DayData {
   daily: DailyEntryRow | null;
@@ -74,3 +77,213 @@ export async function fetchDayData(date: string): Promise<DayData> {
     customMetrics: customMetricsRes.data ?? [],
   };
 }
+
+// ─── Trend & Streak Queries (ported from CLI) ──────────────
+// Dynamic column processing requires loose typing — mirrors CLI pattern
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+type TableName = "daily_entries" | "sleep" | "blood_pressure" | "pullups" | "meals" | "body_composition" | "fasting" | "workouts" | "custom_metrics" | "supplements";
+
+interface TrendConfig {
+  table: TableName;
+  columns: string[];
+  type: "single" | "multi" | "multi-daily-avg" | "daily-sum";
+}
+
+const METRIC_MAP: Record<string, TrendConfig> = {
+  weight: { table: "daily_entries", columns: ["weight"], type: "single" },
+  energy: { table: "daily_entries", columns: ["energy"], type: "single" },
+  sleep: { table: "sleep", columns: ["oura_score", "apple_score", "hours"], type: "multi" },
+  hrv: { table: "sleep", columns: ["avg_hrv"], type: "single" },
+  "hr-sleep": { table: "sleep", columns: ["avg_hr_sleep"], type: "single" },
+  readiness: { table: "sleep", columns: ["oura_readiness"], type: "single" },
+  bp: { table: "blood_pressure", columns: ["systolic", "diastolic"], type: "multi-daily-avg" },
+  pullups: { table: "pullups", columns: ["total_count"], type: "single" },
+  calories: { table: "meals", columns: ["calories"], type: "daily-sum" },
+  protein: { table: "meals", columns: ["protein_g"], type: "daily-sum" },
+  "body-fat": { table: "body_composition", columns: ["body_fat_pct"], type: "single" },
+};
+
+function avg(nums: number[]): number | null {
+  if (nums.length === 0) return null;
+  return nums.reduce((a, b) => a + b, 0) / nums.length;
+}
+
+export interface TrendSummary {
+  min: number | null;
+  max: number | null;
+  avg: number | null;
+  delta: number | null;
+  count: number;
+}
+
+export const EMPTY_TREND_SUMMARY: TrendSummary = { min: null, max: null, avg: null, delta: null, count: 0 };
+
+function singleSummary(values: number[]): TrendSummary {
+  if (values.length === 0) return { ...EMPTY_TREND_SUMMARY };
+  return {
+    min: Math.min(...values),
+    max: Math.max(...values),
+    avg: avg(values),
+    delta: values.length >= 2 ? values[values.length - 1] - values[0] : null,
+    count: values.length,
+  };
+}
+
+function dailySumPoints(rows: any[], col: string): Array<{ date: string; value: number }> {
+  const byDate: Record<string, number> = {};
+  for (const r of rows) {
+    if (r[col] != null) byDate[r.date] = (byDate[r.date] ?? 0) + Number(r[col]);
+  }
+  return Object.entries(byDate)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, value]) => ({ date, value }));
+}
+
+function multiSummaries(columns: string[], points: any[]): Record<string, TrendSummary> {
+  const summaries: Record<string, TrendSummary> = {};
+  for (const col of columns) {
+    const vals = points.map((p: any) => p[col]).filter((v: any) => v != null);
+    summaries[col] = singleSummary(vals);
+  }
+  return summaries;
+}
+
+export interface SingleTrendResult {
+  metric: string;
+  days: number;
+  points: Array<{ date: string; value: number }>;
+  summary: TrendSummary;
+}
+
+export interface MultiTrendResult {
+  metric: string;
+  days: number;
+  points: Array<Record<string, any>>;
+  summaries: Record<string, TrendSummary>;
+}
+
+export type TrendResult = SingleTrendResult | MultiTrendResult;
+
+function todayDate(): string {
+  return formatDate(new Date());
+}
+
+function daysAgoDate(n: number): string {
+  return formatDate(addDays(new Date(), -n));
+}
+
+export async function fetchTrend(metric: string, days: number): Promise<TrendResult> {
+  const cfg = METRIC_MAP[metric];
+  if (!cfg) throw new Error(`Unknown metric: ${metric}`);
+
+  const start = daysAgoDate(days - 1);
+  const end = todayDate();
+  const selectCols = ["date", ...cfg.columns].join(", ");
+
+  const { data: rows, error } = await supabase
+    .from(cfg.table)
+    .select(selectCols)
+    .gte("date", start)
+    .lte("date", end)
+    .order("date", { ascending: true });
+
+  if (error) throw new Error(`Query failed: ${error.message}`);
+  const data = rows ?? [];
+
+  if (cfg.type === "single") {
+    const col = cfg.columns[0];
+    const points = data
+      .filter((r: any) => r[col] != null)
+      .map((r: any) => ({ date: r.date as string, value: r[col] as number }));
+    return { metric, days, points, summary: singleSummary(points.map((p) => p.value)) };
+  }
+
+  if (cfg.type === "multi-daily-avg") {
+    const byDate: Record<string, Record<string, number[]>> = {};
+    for (const r of data as any[]) {
+      if (!byDate[r.date]) {
+        byDate[r.date] = Object.fromEntries(cfg.columns.map((c) => [c, []]));
+      }
+      for (const col of cfg.columns) {
+        if (r[col] != null) byDate[r.date][col].push(r[col]);
+      }
+    }
+    const points = Object.entries(byDate)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, cols]) => {
+        const point: any = { date };
+        for (const col of cfg.columns) point[col] = avg(cols[col]);
+        return point;
+      });
+    return { metric, days, points, summaries: multiSummaries(cfg.columns, points) };
+  }
+
+  if (cfg.type === "multi") {
+    const points = data.map((r: any) => {
+      const point: any = { date: r.date };
+      for (const col of cfg.columns) point[col] = r[col] ?? null;
+      return point;
+    });
+    return { metric, days, points, summaries: multiSummaries(cfg.columns, points) };
+  }
+
+  // daily-sum
+  const points = dailySumPoints(data, cfg.columns[0]);
+  return { metric, days, points, summary: singleSummary(points.map((p) => p.value)) };
+}
+
+// ─── Streaks ─────────────────────────────────────────────
+
+interface StreakConfig {
+  table: TableName;
+  select: string;
+  pass: (row: any) => boolean;
+}
+
+const STREAK_MAP: Record<string, StreakConfig> = {
+  "alcohol-free": { table: "daily_entries", select: "date, alcohol", pass: (r) => r.alcohol === false },
+  fasting: { table: "fasting", select: "date, compliant", pass: (r) => r.compliant === true },
+};
+
+export interface StreakResult {
+  metric: string;
+  current_streak: number;
+  start_date: string | null;
+}
+
+export async function fetchStreak(metric: string): Promise<StreakResult> {
+  const cfg = STREAK_MAP[metric];
+  if (!cfg) throw new Error(`Unknown streak: ${metric}`);
+
+  const today = todayDate();
+  const rangeStart = daysAgoDate(365);
+
+  const { data, error } = await supabase
+    .from(cfg.table)
+    .select(cfg.select)
+    .gte("date", rangeStart)
+    .lte("date", today)
+    .order("date", { ascending: false });
+
+  if (error) throw new Error(`Query failed: ${error.message}`);
+  const rows = data ?? [];
+
+  const rowsByDate = new Map<string, any>();
+  for (const r of rows as any[]) {
+    if (!rowsByDate.has(r.date)) rowsByDate.set(r.date, r);
+  }
+
+  let count = 0;
+  for (let i = 0; ; i++) {
+    const d = daysAgoDate(i);
+    if (d < rangeStart) break;
+    const row = rowsByDate.get(d);
+    if (row && cfg.pass(row)) count++;
+    else break;
+  }
+
+  const startDate = count > 0 ? daysAgoDate(count - 1) : null;
+  return { metric, current_streak: count, start_date: startDate };
+}
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -150,7 +150,7 @@ export type WorkoutType =
   | "hot_tub"
   | "other"
 
-export type ViewType = "calendar" | "daily";
+export type ViewType = "calendar" | "daily" | "metrics";
 
 export type CustomMetricRow = Database["public"]["Tables"]["custom_metrics"]["Row"];
 export type BloodPressureRow = Database["public"]["Tables"]["blood_pressure"]["Row"];


### PR DESCRIPTION
## Summary
- Adds full metrics dashboard at `/?view=metrics` with 7 metric cards: weight trend, sleep scores, fasting/alcohol-free streaks, pullups, blood pressure, and protein intake
- Custom SVG sparkline component with goal lines, time-proportional x-axis, gradient fill
- Web-side `fetchTrend`/`fetchStreak` query functions ported from CLI with aggregation parity (single, multi, multi-daily-avg, daily-sum)
- Configurable time range (7d/14d/30d/90d), partial failure handling with warning banner
- Nav shell converted from static spans to `next/link` with active styling

## Test plan
- [ ] Navigate to Metrics tab — dashboard loads with 30-day default
- [ ] Switch range to 7d/14d/90d — sparklines update
- [ ] Weight card shows goal line at 165 lbs
- [ ] Sleep card shows dual Oura (purple) + Apple (blue) lines
- [ ] Streak cards show current fasting/alcohol-free counts
- [ ] BP card shows systolic (red) + diastolic (blue) overlay
- [ ] Protein card shows goal line at 150g
- [ ] Empty metrics show "Not logged" state
- [ ] Calendar/Metrics nav tabs highlight correctly
- [ ] Responsive: 1-col mobile, 2-col desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)