### PR TITLE
Add delete_meal MCP tool (#38)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ The MCP server exposes these as tools Claude can call directly:
 - `ironcompass_log_bodycomp` — log body composition (Hume Body Pod)
 - `ironcompass_log_metric` — log a custom numeric metric
 - `ironcompass_delete_metric` — delete a custom metric entry by ID
+- `ironcompass_delete_meal` — delete a meal by ID
 - `ironcompass_delete_workout` — delete a workout by ID
 - `ironcompass_query_today` — get today's summary
 - `ironcompass_query_week` — get weekly summary

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ All commands return structured JSON.
 
 ## MCP Server
 
-IronCompass exposes 16 tools via [Model Context Protocol](https://modelcontextprotocol.io/) so Claude can log and query health data directly.
+IronCompass exposes 17 tools via [Model Context Protocol](https://modelcontextprotocol.io/) so Claude can log and query health data directly.
 
 ### Register for this project
 
@@ -153,6 +153,7 @@ Add to that project's `.mcp.json`:
 | `ironcompass_query_trend` | Get trend data for any metric |
 | `ironcompass_query_streak` | Get current streak |
 | `ironcompass_delete_metric` | Delete a custom metric entry |
+| `ironcompass_delete_meal` | Delete a meal entry |
 | `ironcompass_delete_workout` | Delete a workout entry |
 
 ### Claude Code skills

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,7 +68,7 @@ Source integrations (Apple Health, Oura, Hevy, Strava) live in LifeOS, not IronC
 | #34 | Add `indoor_cycle` workout type | **done** |
 | #35 | Add `details` JSONB column to workouts for type-specific data (strength sets, golf scores, etc.) | **done** |
 | #37 | Deduplicate WorkoutType and Database types across CLI and web | todo |
-| #38 | Add `delete_meal` MCP tool | todo |
+| #38 | Add `delete_meal` MCP tool | **done** |
 | #39 | Make workout types table-driven instead of hardcoded | todo |
 | #40 | Structured workout details rendering (generic + type-specific renderers, maps for hike/run) | todo |
 

--- a/cli/src/mcp.ts
+++ b/cli/src/mcp.ts
@@ -238,6 +238,17 @@ server.registerTool("ironcompass_delete_metric", {
   return textResult({ deleted, dashboard_url: dayUrl(deleted.date) });
 });
 
+server.registerTool("ironcompass_delete_meal", {
+  title: "Delete Meal",
+  description: "Delete a meal by its ID",
+  inputSchema: z.object({
+    id: z.string().uuid().describe("Meal UUID to delete"),
+  }),
+}, async ({ id }) => {
+  const deleted = await deleteRowById("meals", id);
+  return textResult({ deleted, dashboard_url: dayUrl(deleted.date) });
+});
+
 server.registerTool("ironcompass_delete_workout", {
   title: "Delete Workout",
   description: "Delete a workout by its ID",

--- a/cli/test/mcp.test.ts
+++ b/cli/test/mcp.test.ts
@@ -65,6 +65,7 @@ const EXPECTED_TOOLS = [
   "ironcompass_log_bodycomp",
   "ironcompass_log_metric",
   "ironcompass_delete_metric",
+  "ironcompass_delete_meal",
   "ironcompass_delete_workout",
 ];
 
@@ -95,7 +96,7 @@ describe("ironcompass MCP server", () => {
     }
   });
 
-  it("lists all 16 tools with correct schemas", async () => {
+  it("lists all 17 tools with correct schemas", async () => {
     const proc = spawnMcp();
     try {
       const response = await initAndSend(proc, {
@@ -108,8 +109,8 @@ describe("ironcompass MCP server", () => {
       assert.ok(response.result, "Expected result");
       const tools = response.result.tools;
 
-      // All 16 tools present
-      assert.equal(tools.length, 16);
+      // All 17 tools present
+      assert.equal(tools.length, 17);
       const names = tools.map((t: any) => t.name).sort();
       assert.deepEqual(names, [...EXPECTED_TOOLS].sort());
 


### PR DESCRIPTION
## Summary

- Add `ironcompass_delete_meal` MCP tool following the same pattern as `delete_metric` and `delete_workout`
- Update MCP test tool count (16 → 17) and expected tools list
- Update README (tool count + table) and CLAUDE.md (MCP tools list)
- Mark #38 as done in ROADMAP

## Test plan

- [x] 27/27 tests pass
- [x] CLI builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)