### PR TITLE
Add weekly summary view with vertical day columns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,13 @@ The MCP server exposes these as tools Claude can call directly:
 - Green=pickleball, Blue=strength, Orange=hike, Purple=golf, Red=run, Rose=indoor_cycle, Gray=rest
 - Multiple workouts per day shown
 - Click day for full details (meals, metrics, notes)
+- 8th column (WK) shows weekly summaries: workout count, sleep hours, weight delta, fasting ratio
+- Click WK column to navigate to dedicated weekly view
+
+### Weekly View
+- Dedicated `?view=weekly&date=<monday>` view with prev/next week navigation
+- Sections: Overview (days logged, weight delta, alcohol), Sleep (avg hours/oura/apple), Workouts (count + type badges + list), Nutrition (avg daily protein/calories), Fasting (compliant days), Pullups (total + active days)
+- URL auto-syncs to Monday of selected week for deep-linking
 
 ### Metrics Dashboard
 - Weight trend line (configurable goal line)
@@ -143,13 +150,6 @@ The MCP server exposes these as tools Claude can call directly:
 - Pullup daily count + trend
 - Blood pressure trend
 - Protein intake vs target
-
-### Weekly Summary
-- Workouts completed vs planned
-- Average sleep score
-- Weight delta
-- Macro averages
-- Streaks
 
 ## Design Direction
 Athletic, bold, dark theme. Think Strava meets a fighter pilot's HUD. Not clinical — motivating. The design should make you want to fill in the data because it looks good when you do.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,7 +47,7 @@ The visual layer. Calendar view + metrics. Deploy to Vercel.
 | #12 | Calendar view component (month view, color-coded workouts) | **done** |
 | #13 | Day detail view (meals, metrics, notes on click) | **done** |
 | #14 | Metrics dashboard (weight trend, sleep, streaks, BP) | todo |
-| #15 | Weekly summary view | todo |
+| #15 | Weekly summary view | **done** |
 | #16 | Deploy to Vercel | todo |
 
 ### Design decision: multi-view navigation

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import Shell from "@/components/layout/shell";
 import Calendar from "@/components/calendar/calendar";
 import DayDetail from "@/components/day-detail/day-detail";
 import MetricsDashboard from "@/components/metrics/metrics-dashboard";
+import WeeklyView from "@/components/weekly/weekly-view";
 import type { ViewType } from "@/lib/types";
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
@@ -25,12 +26,15 @@ export default async function Home({
 
   const currentView: ViewType =
     view === "metrics" ? "metrics" :
+    view === "weekly" ? "weekly" :
     view === "daily" ? "daily" : "calendar";
 
   return (
     <Shell currentView={currentView}>
       {currentView === "metrics" ? (
         <MetricsDashboard />
+      ) : currentView === "weekly" ? (
+        <WeeklyView date={date} backMonth={month} />
       ) : currentView === "daily" && date ? (
         <DayDetail date={date} backMonth={month} />
       ) : (

--- a/src/components/calendar/calendar-week-summary.tsx
+++ b/src/components/calendar/calendar-week-summary.tsx
@@ -1,0 +1,40 @@
+import { useRouter } from "next/navigation";
+import type { WeekSummary } from "@/lib/types";
+
+interface CalendarWeekSummaryProps {
+  monday: string;
+  month: string;
+  summary: WeekSummary | undefined;
+}
+
+export default function CalendarWeekSummary({ monday, month, summary }: CalendarWeekSummaryProps) {
+  const router = useRouter();
+
+  return (
+    <button
+      onClick={() => router.push(`/?view=weekly&date=${monday}&month=${month}`)}
+      className="w-full h-full flex flex-col items-center justify-center gap-1 p-1 rounded-lg border border-transparent hover:border-border hover:bg-surface-hover transition-all min-h-[3.5rem] sm:min-h-[4.5rem]"
+    >
+      {summary ? (
+        <>
+          {summary.workoutCount > 0 && (
+            <span className="text-xs font-mono font-bold text-accent">{summary.workoutCount}w</span>
+          )}
+          {summary.avgSleepHours != null && (
+            <span className="text-[10px] font-mono text-purple-400">{summary.avgSleepHours.toFixed(1)}h</span>
+          )}
+          {summary.weightDelta != null && (
+            <span className={`text-[10px] font-mono ${summary.weightDelta <= 0 ? "text-green-400" : "text-red-400"}`}>
+              {summary.weightDelta > 0 ? "+" : ""}{summary.weightDelta.toFixed(1)}
+            </span>
+          )}
+          {summary.fastingTotal > 0 && (
+            <span className="text-[10px] font-mono text-cyan-400">{summary.fastingCompliant}/{summary.fastingTotal}</span>
+          )}
+        </>
+      ) : (
+        <span className="text-[10px] font-mono text-muted/30">--</span>
+      )}
+    </button>
+  );
+}

--- a/src/components/calendar/calendar.tsx
+++ b/src/components/calendar/calendar.tsx
@@ -3,17 +3,18 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabase";
-import type { WorkoutRow } from "@/lib/types";
-import { getMonday, formatDate, addDays, isSameDay, parseDate } from "@/lib/date";
+import { fetchWeekSummaries } from "@/lib/queries";
+import type { WorkoutRow, WeekSummary } from "@/lib/types";
+import { getMonday, formatDate, addDays, isSameDay, parseDate, SHORT_DAYS } from "@/lib/date";
 import CalendarHeader from "./calendar-header";
 import CalendarDay from "./calendar-day";
-
-const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+import CalendarWeekSummary from "./calendar-week-summary";
 
 export default function Calendar({ initialMonth }: { initialMonth?: string } = {}) {
   const router = useRouter();
   const [currentMonth, setCurrentMonth] = useState<Date | null>(null);
   const [workouts, setWorkouts] = useState<WorkoutRow[]>([]);
+  const [weekSummaries, setWeekSummaries] = useState<Map<string, WeekSummary>>(new Map());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -28,7 +29,7 @@ export default function Calendar({ initialMonth }: { initialMonth?: string } = {
     }
   }, [initialMonth]);
 
-  const fetchWorkouts = useCallback(
+  const fetchData = useCallback(
     async (month: Date, signal: AbortSignal) => {
       setLoading(true);
       setError(null);
@@ -36,22 +37,42 @@ export default function Calendar({ initialMonth }: { initialMonth?: string } = {
       const firstOfMonth = new Date(month.getFullYear(), month.getMonth(), 1);
       const gridStart = getMonday(firstOfMonth);
       const gridEnd = addDays(gridStart, 41);
+      const gridStartStr = formatDate(gridStart);
+      const gridEndStr = formatDate(gridEnd);
 
-      const { data, error: fetchError } = await supabase
-        .from("workouts")
-        .select("*")
-        .gte("date", formatDate(gridStart))
-        .lte("date", formatDate(gridEnd))
-        .order("date");
+      const [workoutsResult, summariesResult] = await Promise.allSettled([
+        supabase
+          .from("workouts")
+          .select("*")
+          .gte("date", gridStartStr)
+          .lte("date", gridEndStr)
+          .order("date"),
+        fetchWeekSummaries(gridStartStr, gridEndStr),
+      ]);
 
       if (signal.aborted) return;
 
-      if (fetchError) {
-        setError(fetchError.message);
-        setWorkouts([]);
+      // Workouts
+      if (workoutsResult.status === "fulfilled") {
+        const { data, error: fetchError } = workoutsResult.value;
+        if (fetchError) {
+          setError(fetchError.message);
+          setWorkouts([]);
+        } else {
+          setWorkouts(data ?? []);
+        }
       } else {
-        setWorkouts(data ?? []);
+        setError("Failed to fetch workouts");
+        setWorkouts([]);
       }
+
+      // Week summaries — independent, don't block calendar
+      if (summariesResult.status === "fulfilled") {
+        setWeekSummaries(summariesResult.value);
+      } else {
+        setWeekSummaries(new Map());
+      }
+
       setLoading(false);
     },
     []
@@ -67,9 +88,9 @@ export default function Calendar({ initialMonth }: { initialMonth?: string } = {
       window.history.replaceState(window.history.state, "", url.toString());
     }
     const controller = new AbortController();
-    fetchWorkouts(currentMonth, controller.signal);
+    fetchData(currentMonth, controller.signal);
     return () => controller.abort();
-  }, [currentMonth, fetchWorkouts]);
+  }, [currentMonth, fetchData]);
 
   const gridStart = useMemo(() => {
     if (!currentMonth) return null;
@@ -96,6 +117,12 @@ export default function Calendar({ initialMonth }: { initialMonth?: string } = {
 
   if (!currentMonth) {
     return <LoadingSkeleton />;
+  }
+
+  // Build rows of 7 days + 1 summary
+  const rows: Date[][] = [];
+  for (let i = 0; i < 42; i += 7) {
+    rows.push(cells.slice(i, i + 7));
   }
 
   return (
@@ -125,8 +152,8 @@ export default function Calendar({ initialMonth }: { initialMonth?: string } = {
       )}
 
       {/* Day-of-week labels */}
-      <div className="grid grid-cols-7 mb-1">
-        {DAY_LABELS.map((label) => (
+      <div className="grid grid-cols-7 sm:grid-cols-[repeat(7,1fr)_4rem] mb-1">
+        {SHORT_DAYS.map((label) => (
           <div
             key={label}
             className="text-center text-[10px] font-mono font-medium tracking-widest uppercase text-muted py-2"
@@ -134,39 +161,57 @@ export default function Calendar({ initialMonth }: { initialMonth?: string } = {
             {label}
           </div>
         ))}
+        <div className="hidden sm:block text-center text-[10px] font-mono font-medium tracking-widest uppercase text-muted py-2">
+          WK
+        </div>
       </div>
 
       {/* Calendar grid */}
-      <div className="grid grid-cols-7 gap-px rounded-lg overflow-hidden border border-border bg-border">
+      <div className="grid grid-cols-7 sm:grid-cols-[repeat(7,1fr)_4rem] gap-px rounded-lg overflow-hidden border border-border bg-border">
         {loading ? (
-          Array.from({ length: 42 }).map((_, i) => (
+          Array.from({ length: 48 }).map((_, i) => (
             <div
               key={i}
-              className="skeleton min-h-[3.5rem] sm:min-h-[4.5rem]"
-              style={{ animationDelay: `${(i % 7) * 50}ms` }}
+              className={`skeleton min-h-[3.5rem] sm:min-h-[4.5rem] ${i % 8 === 7 ? "hidden sm:block" : ""}`}
+              style={{ animationDelay: `${(i % 8) * 50}ms` }}
             />
           ))
         ) : (
-          cells.map((date, i) => {
-            const key = formatDate(date);
-            const dayWorkouts = workoutsByDate.get(key) ?? [];
-            return (
+          rows.map((week, rowIndex) => {
+            const mondayStr = formatDate(week[0]);
+            const summary = weekSummaries.get(mondayStr);
+            return [
+              ...week.map((date, dayIndex) => {
+                const key = formatDate(date);
+                const dayWorkouts = workoutsByDate.get(key) ?? [];
+                return (
+                  <div
+                    key={key}
+                    className="bg-surface"
+                    style={{
+                      animation: `cell-in 0.2s ease-out ${dayIndex * 30}ms both`,
+                    }}
+                  >
+                    <CalendarDay
+                      date={date}
+                      workouts={dayWorkouts}
+                      isCurrentMonth={date.getMonth() === currentMonth.getMonth()}
+                      isToday={isSameDay(date, today)}
+                      onClick={() => router.push(`/?view=daily&date=${key}&month=${formatDate(currentMonth)}`)}
+                    />
+                  </div>
+                );
+              }),
               <div
-                key={key}
-                className="bg-surface"
+                key={`wk-${rowIndex}`}
+                className="hidden sm:block bg-surface"
                 style={{
-                  animation: `cell-in 0.2s ease-out ${(i % 7) * 30}ms both`,
+                  animation: `cell-in 0.2s ease-out 210ms both`,
                 }}
               >
-                <CalendarDay
-                  date={date}
-                  workouts={dayWorkouts}
-                  isCurrentMonth={date.getMonth() === currentMonth.getMonth()}
-                  isToday={isSameDay(date, today)}
-                  onClick={() => router.push(`/?view=daily&date=${key}&month=${formatDate(currentMonth)}`)}
-                />
-              </div>
-            );
+                <CalendarWeekSummary monday={mondayStr} month={formatDate(currentMonth)} summary={summary} />
+              </div>,
+            ];
           })
         )}
       </div>
@@ -185,12 +230,12 @@ function LoadingSkeleton() {
           <div className="skeleton h-9 w-9 rounded" />
         </div>
       </div>
-      <div className="grid grid-cols-7 gap-px rounded-lg overflow-hidden border border-border bg-border">
-        {Array.from({ length: 42 }).map((_, i) => (
+      <div className="grid grid-cols-7 sm:grid-cols-[repeat(7,1fr)_4rem] gap-px rounded-lg overflow-hidden border border-border bg-border">
+        {Array.from({ length: 48 }).map((_, i) => (
           <div
             key={i}
-            className="skeleton min-h-[3.5rem] sm:min-h-[4.5rem]"
-            style={{ animationDelay: `${(i % 7) * 50}ms` }}
+            className={`skeleton min-h-[3.5rem] sm:min-h-[4.5rem] ${i % 8 === 7 ? "hidden sm:block" : ""}`}
+            style={{ animationDelay: `${(i % 8) * 50}ms` }}
           />
         ))}
       </div>

--- a/src/components/day-detail/section-workouts.tsx
+++ b/src/components/day-detail/section-workouts.tsx
@@ -1,23 +1,7 @@
 import type { WorkoutRow } from "@/lib/types";
-import { getWorkoutColor } from "@/lib/types";
 import { formatTime } from "@/lib/date";
 import SectionCard from "./section-card";
-
-function WorkoutTypeBadge({ type }: { type: string }) {
-  const color = getWorkoutColor(type);
-  return (
-    <span
-      className="inline-block px-2 py-0.5 rounded text-[10px] font-mono font-semibold uppercase tracking-wider"
-      style={{
-        color,
-        backgroundColor: `${color}15`,
-        border: `1px solid ${color}40`,
-      }}
-    >
-      {type}
-    </span>
-  );
-}
+import WorkoutTypeBadge from "@/components/ui/workout-type-badge";
 
 function WorkoutCard({ workout }: { workout: WorkoutRow }) {
   const stats = [

--- a/src/components/layout/shell.tsx
+++ b/src/components/layout/shell.tsx
@@ -3,6 +3,7 @@ import type { ViewType } from "@/lib/types";
 
 const NAV_ITEMS: { label: string; href: string; views: ViewType[] }[] = [
   { label: "Calendar", href: "/", views: ["calendar", "daily"] },
+  { label: "Weekly", href: "/?view=weekly", views: ["weekly"] },
   { label: "Metrics", href: "/?view=metrics", views: ["metrics"] },
 ];
 
@@ -35,9 +36,6 @@ export default function Shell({ children, currentView = "calendar" }: { children
                 </Link>
               );
             })}
-            <span className="px-3 py-1.5 text-xs font-mono tracking-wider uppercase text-muted cursor-not-allowed">
-              Weekly
-            </span>
           </nav>
         </div>
       </header>

--- a/src/components/ui/workout-type-badge.tsx
+++ b/src/components/ui/workout-type-badge.tsx
@@ -1,0 +1,6 @@
+import Badge from "@/components/day-detail/badge";
+import { getWorkoutColor } from "@/lib/types";
+
+export default function WorkoutTypeBadge({ type }: { type: string }) {
+  return <Badge label={type} color={getWorkoutColor(type)} />;
+}

--- a/src/components/weekly/weekly-header.tsx
+++ b/src/components/weekly/weekly-header.tsx
@@ -1,0 +1,65 @@
+import { MONTHS } from "@/lib/date";
+
+interface WeeklyHeaderProps {
+  monday: Date;
+  sunday: Date;
+  onPrev: () => void;
+  onNext: () => void;
+  onThisWeek: () => void;
+}
+
+function formatRange(monday: Date, sunday: Date): string {
+  const mMonth = MONTHS[monday.getMonth()].slice(0, 3);
+  const sMonth = MONTHS[sunday.getMonth()].slice(0, 3);
+  const mYear = monday.getFullYear();
+  const sYear = sunday.getFullYear();
+
+  if (mYear !== sYear) {
+    return `${mMonth} ${monday.getDate()}, ${mYear} – ${sMonth} ${sunday.getDate()}, ${sYear}`;
+  }
+  if (monday.getMonth() === sunday.getMonth()) {
+    return `${mMonth} ${monday.getDate()} – ${sunday.getDate()}, ${sYear}`;
+  }
+  return `${mMonth} ${monday.getDate()} – ${sMonth} ${sunday.getDate()}, ${sYear}`;
+}
+
+export default function WeeklyHeader({
+  monday,
+  sunday,
+  onPrev,
+  onNext,
+  onThisWeek,
+}: WeeklyHeaderProps) {
+  return (
+    <div className="flex items-center justify-between mb-4">
+      <div className="flex items-baseline gap-3">
+        <h1 className="text-2xl sm:text-3xl font-mono font-bold tracking-tight text-foreground">
+          {formatRange(monday, sunday)}
+        </h1>
+      </div>
+
+      <div className="flex items-center gap-1">
+        <button
+          onClick={onPrev}
+          className="w-9 h-9 flex items-center justify-center rounded border border-border bg-surface text-muted hover:text-foreground hover:border-accent/40 hover:bg-accent/5 transition-all active:scale-95 font-mono"
+          aria-label="Previous week"
+        >
+          &#x2039;
+        </button>
+        <button
+          onClick={onThisWeek}
+          className="h-9 px-3 flex items-center justify-center rounded border border-border bg-surface text-xs font-mono font-medium tracking-wider uppercase text-muted hover:text-foreground hover:border-accent/40 hover:bg-accent/5 transition-all active:scale-95"
+        >
+          This Week
+        </button>
+        <button
+          onClick={onNext}
+          className="w-9 h-9 flex items-center justify-center rounded border border-border bg-surface text-muted hover:text-foreground hover:border-accent/40 hover:bg-accent/5 transition-all active:scale-95 font-mono"
+          aria-label="Next week"
+        >
+          &#x203a;
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/weekly/weekly-view.tsx
+++ b/src/components/weekly/weekly-view.tsx
@@ -1,0 +1,567 @@
+"use client";
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { getMonday, formatDate, addDays, parseDate, SHORT_DAYS } from "@/lib/date";
+import { fetchWeekData } from "@/lib/queries";
+import type { WeekData, DaySummary } from "@/lib/types";
+import { getWorkoutColor } from "@/lib/types";
+import WeeklyHeader from "./weekly-header";
+import SectionCard from "@/components/day-detail/section-card";
+import WorkoutTypeBadge from "@/components/ui/workout-type-badge";
+
+const SECTIONS = [
+  { key: "vitals", label: "Vitals", accent: "#22c55e" },
+  { key: "sleep", label: "Sleep", accent: "#a855f7" },
+  { key: "workouts", label: "Workouts", accent: "#3b82f6" },
+  { key: "nutrition", label: "Nutrition", accent: "#f97316" },
+  { key: "fasting", label: "Fasting", accent: "#06b6d4" },
+  { key: "pullups", label: "Pullups", accent: "#eab308" },
+] as const;
+
+type SectionKey = (typeof SECTIONS)[number]["key"];
+
+export default function WeeklyView({ date, backMonth }: { date?: string; backMonth?: string }) {
+  const router = useRouter();
+  const [monday, setMonday] = useState<Date | null>(null);
+  const [hasNavigated, setHasNavigated] = useState(false);
+  const [data, setData] = useState<WeekData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const base = date ? parseDate(date) : new Date();
+    setMonday(getMonday(base));
+  }, [date]);
+
+  const mondayStr = useMemo(() => (monday ? formatDate(monday) : null), [monday]);
+  const sunday = useMemo(() => (monday ? addDays(monday, 6) : null), [monday]);
+
+  // Sync URL (date + month)
+  useEffect(() => {
+    if (!mondayStr || !monday) return;
+    const url = new URL(window.location.href);
+    const monthStr = formatDate(new Date(monday.getFullYear(), monday.getMonth(), 1));
+    if (url.searchParams.get("date") !== mondayStr || url.searchParams.get("month") !== monthStr) {
+      url.searchParams.set("view", "weekly");
+      url.searchParams.set("date", mondayStr);
+      url.searchParams.set("month", monthStr);
+      window.history.replaceState(window.history.state, "", url.toString());
+    }
+  }, [mondayStr, monday]);
+
+  const loadData = useCallback(async (start: string, signal: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchWeekData(start);
+      if (!signal.aborted) { setData(result); setLoading(false); }
+    } catch (err) {
+      if (!signal.aborted) { setData(null); setError(err instanceof Error ? err.message : "Failed to load"); setLoading(false); }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!mondayStr) return;
+    const controller = new AbortController();
+    loadData(mondayStr, controller.signal);
+    return () => controller.abort();
+  }, [mondayStr, loadData]);
+
+  const navigate = useCallback((offset: number) => {
+    setHasNavigated(true);
+    setMonday((prev) => (prev ? addDays(prev, offset) : null));
+  }, []);
+
+  const today = useMemo(() => formatDate(new Date()), []);
+
+  if (!monday || !sunday) return <LoadingSkeleton />;
+
+  const calendarMonth = backMonth && !hasNavigated
+    ? backMonth
+    : formatDate(new Date(monday.getFullYear(), monday.getMonth(), 1));
+
+  return (
+    <div className="animate-slide-in">
+      <div className="mb-3">
+        <Link href={`/?month=${calendarMonth}`} className="text-xs font-mono text-muted hover:text-accent transition-colors">
+          &larr; Calendar
+        </Link>
+      </div>
+
+      <WeeklyHeader
+        monday={monday}
+        sunday={sunday}
+        onPrev={() => navigate(-7)}
+        onNext={() => navigate(7)}
+        onThisWeek={() => { setHasNavigated(true); setMonday(getMonday(new Date())); }}
+      />
+
+      {error && (
+        <div className="mb-4 px-3 py-2 rounded border border-red-500/30 bg-red-500/5 text-red-400 text-xs font-mono">{error}</div>
+      )}
+
+      {loading ? (
+        <LoadingGrid />
+      ) : data ? (
+        <>
+          {/* Day columns grid */}
+          <div className="overflow-x-auto -mx-4 sm:mx-0">
+            <div className="min-w-[900px] px-4 sm:px-0">
+              {/* Column headers */}
+              <div className="grid grid-cols-[repeat(7,1fr)_minmax(10rem,1fr)] gap-px mb-px">
+                {data.days.map((day, i) => {
+                  const isToday = day.date === today;
+                  return (
+                    <button
+                      key={day.date}
+                      onClick={() => router.push(`/?view=daily&date=${day.date}&month=${day.date.slice(0, 7)}-01`)}
+                      className={`text-center py-2 rounded-t-lg transition-colors hover:bg-surface-hover ${isToday ? "bg-accent/5" : "bg-surface"}`}
+                    >
+                      <div className="text-[10px] font-mono font-medium tracking-widest uppercase text-muted">{SHORT_DAYS[i]}</div>
+                      <div className={`text-sm font-mono ${isToday ? "text-accent font-bold" : "text-foreground"}`}>
+                        {parseInt(day.date.slice(8))}
+                      </div>
+                    </button>
+                  );
+                })}
+                <div className="text-center py-2 bg-accent/5 rounded-t-lg">
+                  <div className="text-[10px] font-mono font-medium tracking-widest uppercase text-accent">Summary</div>
+                  <div className="text-sm font-mono text-accent font-bold">WK</div>
+                </div>
+              </div>
+
+              {/* Sections grid — each section is a row spanning all 8 columns */}
+              <div className="rounded-b-lg overflow-hidden border border-border bg-border flex flex-col gap-px">
+                {SECTIONS.map((section) => (
+                  <div key={section.key} className="grid grid-cols-[repeat(7,1fr)_minmax(10rem,1fr)] gap-px">
+                    {data.days.map((day, i) => (
+                      <div
+                        key={day.date}
+                        className="bg-surface px-2 py-2 min-h-[3rem]"
+                        style={i === 0 ? { borderLeft: `2px solid ${section.accent}` } : undefined}
+                      >
+                        {i === 0 && (
+                          <div className="text-[9px] font-mono font-semibold tracking-[0.15em] uppercase mb-1" style={{ color: section.accent }}>
+                            {section.label}
+                          </div>
+                        )}
+                        <DayCell section={section.key} day={day} />
+                      </div>
+                    ))}
+                    <div className="bg-accent/[0.03] px-2 py-2 min-h-[3rem]">
+                      <SummaryCell section={section.key} summary={data.summary} />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Summary cards */}
+          <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+            <WorkoutSectionCard data={data} />
+            <NutritionSectionCard data={data} />
+            <SleepSectionCard data={data} />
+            <HighlightsCard data={data} />
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+// ─── Grid Cells ──────────────────────────────────────
+
+function DayCell({ section, day }: { section: SectionKey; day: DaySummary }) {
+  switch (section) {
+    case "vitals":
+      if (day.weight == null && day.energy == null && day.alcohol == null)
+        return <Empty />;
+      return (
+        <div className="space-y-0.5">
+          {day.weight != null && <Val v={day.weight} u="lbs" />}
+          {day.energy != null && <div><Val v={`${day.energy}/5`} u="nrg" /></div>}
+          {day.alcohol != null && (
+            <div className={`text-[10px] font-mono ${day.alcohol ? "text-red-400" : "text-green-400"}`}>
+              {day.alcohol ? "Alcohol" : "No alc"}
+            </div>
+          )}
+        </div>
+      );
+    case "sleep":
+      if (day.sleepHours == null) return <Empty />;
+      return (
+        <div className="space-y-0.5">
+          <Val v={day.sleepHours.toFixed(1)} u="h" />
+          {day.ouraScore != null && <div className="text-[10px] font-mono text-muted">Oura {day.ouraScore}</div>}
+          {day.appleScore != null && <div className="text-[10px] font-mono text-muted">Apple {day.appleScore}</div>}
+        </div>
+      );
+    case "workouts":
+      if (day.workouts.length === 0) return <Empty />;
+      return (
+        <div className="flex flex-col gap-1">
+          {day.workouts.map((w) => (
+            <div key={w.id} className="flex items-center gap-1">
+              <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: getWorkoutColor(w.type) }} />
+              <span className="text-[10px] font-mono text-foreground/80 truncate">{w.type}</span>
+              {w.duration_min != null && <span className="text-[10px] font-mono text-muted">{w.duration_min}m</span>}
+            </div>
+          ))}
+        </div>
+      );
+    case "nutrition":
+      if (day.totalProtein == null && day.totalCalories == null) return <Empty />;
+      return (
+        <div className="space-y-0.5">
+          {day.totalProtein != null && <Val v={Math.round(day.totalProtein)} u="g P" />}
+          {day.totalCalories != null && <div className="text-[10px] font-mono text-muted">{Math.round(day.totalCalories)} cal</div>}
+        </div>
+      );
+    case "fasting":
+      if (day.fastingCompliant == null) return <Empty />;
+      return (
+        <span className={`text-xs font-mono ${day.fastingCompliant ? "text-green-400" : "text-red-400"}`}>
+          {day.fastingCompliant ? "\u2713" : "\u2717"}
+        </span>
+      );
+    case "pullups":
+      if (day.pullups == null) return <Empty />;
+      return <Val v={day.pullups} />;
+  }
+}
+
+function SummaryCell({ section, summary }: { section: SectionKey; summary: WeekData["summary"] }) {
+  switch (section) {
+    case "vitals":
+      return (
+        <div className="space-y-0.5">
+          {summary.weight.delta != null ? <Delta v={summary.weight.delta} u="lbs" /> : <Empty />}
+          {summary.alcohol.daysWithout > 0 && (
+            <div className="text-[10px] font-mono text-green-400">{summary.alcohol.daysWithout} alc-free</div>
+          )}
+        </div>
+      );
+    case "sleep":
+      if (summary.sleep.avgHours == null) return <Empty />;
+      return (
+        <div className="space-y-0.5">
+          <Val v={summary.sleep.avgHours.toFixed(1)} u="h avg" />
+          {summary.sleep.avgOura != null && <div className="text-[10px] font-mono text-muted">Oura {Math.round(summary.sleep.avgOura)} avg</div>}
+        </div>
+      );
+    case "workouts":
+      if (summary.workouts.total === 0) return <Empty />;
+      return (
+        <div>
+          <Val v={summary.workouts.total} u="total" />
+          <div className="flex flex-wrap gap-1 mt-1">
+            {summary.workouts.types.map((t) => (
+              <span key={t} className="w-2 h-2 rounded-full" style={{ backgroundColor: getWorkoutColor(t) }} />
+            ))}
+          </div>
+        </div>
+      );
+    case "nutrition":
+      if (summary.meals.avgDailyProtein == null && summary.meals.avgDailyCalories == null) return <Empty />;
+      return (
+        <div className="space-y-0.5">
+          {summary.meals.avgDailyProtein != null && <Val v={Math.round(summary.meals.avgDailyProtein)} u="g avg" />}
+          {summary.meals.avgDailyCalories != null && (
+            <div className="text-[10px] font-mono text-muted">{Math.round(summary.meals.avgDailyCalories)} cal avg</div>
+          )}
+        </div>
+      );
+    case "fasting":
+      if (summary.fasting.totalDays === 0) return <Empty />;
+      return <Val v={`${summary.fasting.compliantDays}/${summary.fasting.totalDays}`} />;
+    case "pullups":
+      if (summary.pullups.total === 0) return <Empty />;
+      return (
+        <div className="space-y-0.5">
+          <Val v={summary.pullups.total} u="total" />
+          <div className="text-[10px] font-mono text-muted">{summary.pullups.days} day{summary.pullups.days !== 1 ? "s" : ""}</div>
+        </div>
+      );
+  }
+}
+
+// ─── Summary Cards ──────────────────────────────────
+
+function ExpandToggle({ expanded, onToggle }: { expanded: boolean; onToggle: () => void }) {
+  return (
+    <button onClick={onToggle} className="text-[10px] font-mono text-accent hover:text-accent/80 transition-colors">
+      {expanded ? "\u25B2 Hide" : "\u25BC Details"}
+    </button>
+  );
+}
+
+function WorkoutSectionCard({ data }: { data: WeekData }) {
+  const [expanded, setExpanded] = useState(false);
+  const { summary, days } = data;
+  const allWorkouts = days.flatMap((d) => d.workouts.map((w) => ({ ...w, dayDate: d.date })));
+
+  if (summary.workouts.total === 0) {
+    return (
+      <SectionCard title="Workouts" accent="#3b82f6">
+        <p className="text-sm text-muted/50 font-mono">No workouts</p>
+      </SectionCard>
+    );
+  }
+
+  return (
+    <SectionCard title="Workouts" accent="#3b82f6">
+      <div className="flex items-baseline justify-between mb-2">
+        <p className="text-sm font-mono text-foreground">
+          {summary.workouts.total} workout{summary.workouts.total !== 1 ? "s" : ""}
+          <span className="text-muted ml-1">&middot; {summary.workouts.types.length} type{summary.workouts.types.length !== 1 ? "s" : ""}</span>
+        </p>
+        <ExpandToggle expanded={expanded} onToggle={() => setExpanded(!expanded)} />
+      </div>
+      <div className="flex flex-wrap gap-1 mb-2">
+        {summary.workouts.types.map((t) => <WorkoutTypeBadge key={t} type={t} />)}
+      </div>
+      {expanded && (
+        <div className="mt-3 border-t border-border pt-3 space-y-2">
+          {allWorkouts.map((w) => (
+            <div key={w.id} className="flex items-center gap-2 text-xs font-mono">
+              <span className="text-muted w-12">{w.dayDate.slice(5)}</span>
+              <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: getWorkoutColor(w.type) }} />
+              <span className="text-foreground/80">{w.type}</span>
+              {w.duration_min != null && <span className="text-muted">{w.duration_min}m</span>}
+              {w.distance_mi != null && <span className="text-muted">{w.distance_mi}mi</span>}
+              {w.calories != null && <span className="text-muted">{w.calories}cal</span>}
+            </div>
+          ))}
+        </div>
+      )}
+    </SectionCard>
+  );
+}
+
+function NutritionSectionCard({ data }: { data: WeekData }) {
+  const [expanded, setExpanded] = useState(false);
+  const { summary, days } = data;
+  const daysWithMeals = days.filter((d) => d.totalProtein != null || d.totalCalories != null);
+
+  if (summary.meals.avgDailyProtein == null && summary.meals.avgDailyCalories == null) {
+    return (
+      <SectionCard title="Nutrition" accent="#f97316">
+        <p className="text-sm text-muted/50 font-mono">No meals logged</p>
+      </SectionCard>
+    );
+  }
+
+  const bestCalDay = daysWithMeals.reduce<DaySummary | null>((best, d) =>
+    d.totalCalories != null && (best == null || (best.totalCalories ?? 0) < d.totalCalories) ? d : best, null);
+
+  return (
+    <SectionCard title="Nutrition" accent="#f97316">
+      <div className="flex items-baseline justify-between mb-2">
+        <p className="text-sm font-mono text-foreground">
+          {summary.meals.avgDailyProtein != null && <>{Math.round(summary.meals.avgDailyProtein)}g P</>}
+          {summary.meals.avgDailyCalories != null && <span className="text-muted ml-1">{summary.meals.avgDailyProtein != null && <>&middot; </>}{Math.round(summary.meals.avgDailyCalories)} cal avg</span>}
+        </p>
+        {daysWithMeals.length > 0 && (
+          <ExpandToggle expanded={expanded} onToggle={() => setExpanded(!expanded)} />
+        )}
+      </div>
+      {bestCalDay && (
+        <p className="text-[10px] font-mono text-muted">
+          Best: {SHORT_DAYS[days.indexOf(bestCalDay)]} {bestCalDay.totalCalories != null && Math.round(bestCalDay.totalCalories)} cal
+        </p>
+      )}
+      {expanded && (
+        <div className="mt-3 border-t border-border pt-3">
+          <table className="w-full text-xs font-mono">
+            <thead>
+              <tr className="text-muted text-left">
+                <th className="pb-1 font-medium">Day</th>
+                <th className="pb-1 font-medium text-right">Protein</th>
+                <th className="pb-1 font-medium text-right">Calories</th>
+              </tr>
+            </thead>
+            <tbody>
+              {days.map((d, i) => (
+                <tr key={d.date} className="border-t border-border/50">
+                  <td className="py-1 text-muted">{SHORT_DAYS[i]}</td>
+                  <td className="py-1 text-right text-foreground/80">{d.totalProtein != null ? `${Math.round(d.totalProtein)}g` : "--"}</td>
+                  <td className="py-1 text-right text-foreground/80">{d.totalCalories != null ? Math.round(d.totalCalories) : "--"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </SectionCard>
+  );
+}
+
+function SleepSectionCard({ data }: { data: WeekData }) {
+  const [expanded, setExpanded] = useState(false);
+  const { summary, days } = data;
+  const daysWithSleep = days.filter((d) => d.sleepHours != null);
+
+  if (summary.sleep.avgHours == null) {
+    return (
+      <SectionCard title="Sleep" accent="#a855f7">
+        <p className="text-sm text-muted/50 font-mono">No sleep data</p>
+      </SectionCard>
+    );
+  }
+
+  const bestSleepDay = daysWithSleep.reduce<DaySummary | null>((best, d) =>
+    d.sleepHours != null && (best == null || (best.sleepHours ?? 0) < d.sleepHours) ? d : best, null);
+
+  return (
+    <SectionCard title="Sleep" accent="#a855f7">
+      <div className="flex items-baseline justify-between mb-2">
+        <p className="text-sm font-mono text-foreground">
+          {summary.sleep.avgHours.toFixed(1)}h avg
+          {summary.sleep.avgOura != null && <span className="text-muted ml-1">&middot; Oura {Math.round(summary.sleep.avgOura)}</span>}
+        </p>
+        {daysWithSleep.length > 0 && (
+          <ExpandToggle expanded={expanded} onToggle={() => setExpanded(!expanded)} />
+        )}
+      </div>
+      {bestSleepDay && (
+        <p className="text-[10px] font-mono text-muted">
+          Best: {SHORT_DAYS[days.indexOf(bestSleepDay)]} {bestSleepDay.sleepHours?.toFixed(1)}h
+        </p>
+      )}
+      {expanded && (
+        <div className="mt-3 border-t border-border pt-3">
+          <table className="w-full text-xs font-mono">
+            <thead>
+              <tr className="text-muted text-left">
+                <th className="pb-1 font-medium">Day</th>
+                <th className="pb-1 font-medium text-right">Hours</th>
+                <th className="pb-1 font-medium text-right">Oura</th>
+                <th className="pb-1 font-medium text-right">Apple</th>
+              </tr>
+            </thead>
+            <tbody>
+              {days.map((d, i) => (
+                <tr key={d.date} className="border-t border-border/50">
+                  <td className="py-1 text-muted">{SHORT_DAYS[i]}</td>
+                  <td className="py-1 text-right text-foreground/80">{d.sleepHours != null ? d.sleepHours.toFixed(1) : "--"}</td>
+                  <td className="py-1 text-right text-foreground/80">{d.ouraScore ?? "--"}</td>
+                  <td className="py-1 text-right text-foreground/80">{d.appleScore ?? "--"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </SectionCard>
+  );
+}
+
+function HighlightsCard({ data }: { data: WeekData }) {
+  const { summary } = data;
+  return (
+    <SectionCard title="Highlights" accent="#22c55e">
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <p className="text-[10px] font-mono uppercase tracking-wider text-muted mb-0.5">Weight</p>
+          {summary.weight.first != null && summary.weight.last != null ? (
+            <p className="text-sm font-mono text-foreground">
+              {summary.weight.first} &rarr; {summary.weight.last}
+              {summary.weight.delta != null && (
+                <span className={`ml-1 ${summary.weight.delta > 0 ? "text-red-400" : "text-green-400"}`}>
+                  ({summary.weight.delta > 0 ? "+" : ""}{summary.weight.delta.toFixed(1)})
+                </span>
+              )}
+            </p>
+          ) : (
+            <p className="text-sm font-mono text-muted/50">--</p>
+          )}
+        </div>
+        <div>
+          <p className="text-[10px] font-mono uppercase tracking-wider text-muted mb-0.5">Fasting</p>
+          {summary.fasting.totalDays > 0 ? (
+            <p className="text-sm font-mono text-foreground">
+              {summary.fasting.compliantDays}/{summary.fasting.totalDays} compliant
+            </p>
+          ) : (
+            <p className="text-sm font-mono text-muted/50">--</p>
+          )}
+        </div>
+        <div>
+          <p className="text-[10px] font-mono uppercase tracking-wider text-muted mb-0.5">Alcohol-free</p>
+          <p className="text-sm font-mono text-foreground">
+            {(summary.alcohol.daysWith + summary.alcohol.daysWithout) > 0
+              ? `${summary.alcohol.daysWithout} day${summary.alcohol.daysWithout !== 1 ? "s" : ""}`
+              : <span className="text-muted/50">--</span>}
+          </p>
+        </div>
+        <div>
+          <p className="text-[10px] font-mono uppercase tracking-wider text-muted mb-0.5">Pullups</p>
+          <p className="text-sm font-mono text-foreground">
+            {summary.pullups.total > 0
+              ? <>{summary.pullups.total} <span className="text-muted">({summary.pullups.days} day{summary.pullups.days !== 1 ? "s" : ""})</span></>
+              : <span className="text-muted/50">--</span>}
+          </p>
+        </div>
+      </div>
+    </SectionCard>
+  );
+}
+
+// ─── Helpers ──────────────────────────────────────────
+
+function Val({ v, u }: { v: string | number; u?: string }) {
+  return (
+    <span className="text-xs font-mono text-foreground">
+      {v}{u && <span className="text-muted ml-0.5">{u}</span>}
+    </span>
+  );
+}
+
+function Delta({ v, u }: { v: number; u?: string }) {
+  const positive = v > 0;
+  return (
+    <span className={`text-xs font-mono ${positive ? "text-red-400" : "text-green-400"}`}>
+      {positive ? "+" : ""}{v.toFixed(1)}{u && <span className="text-muted ml-0.5">{u}</span>}
+    </span>
+  );
+}
+
+function Empty() {
+  return <span className="text-[10px] font-mono text-muted/20">--</span>;
+}
+
+// ─── Loading States ──────────────────────────────────
+
+function LoadingSkeleton() {
+  return (
+    <div>
+      <div className="skeleton h-4 w-20 rounded mb-3" />
+      <div className="flex items-center justify-between mb-4">
+        <div className="skeleton h-8 w-64 rounded" />
+        <div className="flex gap-1">
+          <div className="skeleton h-9 w-9 rounded" />
+          <div className="skeleton h-9 w-24 rounded" />
+          <div className="skeleton h-9 w-9 rounded" />
+        </div>
+      </div>
+      <LoadingGrid />
+    </div>
+  );
+}
+
+function LoadingGrid() {
+  return (
+    <div className="overflow-x-auto -mx-4 sm:mx-0">
+      <div className="min-w-[900px] px-4 sm:px-0">
+        <div className="grid grid-cols-[repeat(7,1fr)_minmax(10rem,1fr)] gap-px rounded-lg overflow-hidden border border-border bg-border">
+          {Array.from({ length: 48 }).map((_, i) => (
+            <div key={i} className="skeleton min-h-[3rem]" style={{ animationDelay: `${(i % 8) * 40}ms` }} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -33,6 +33,8 @@ export const DAYS = [
   "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
 ];
 
+export const SHORT_DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
 export function formatTime(iso: string): string {
   const d = new Date(iso);
   return d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit", hour12: true });

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,16 +1,19 @@
 import { supabase } from "./supabase";
-import { formatDate, addDays } from "./date";
+import { formatDate, addDays, getMonday } from "./date";
 import type {
   BloodPressureRow,
   BodyCompositionRow,
   CustomMetricRow,
   DailyEntryRow,
+  DaySummary,
   FastingRow,
   MealRow,
   PullupsRow,
   SleepRow,
   SupplementsRow,
   WorkoutRow,
+  WeekData,
+  WeekSummary,
 } from "./types";
 
 // ─── Day Data ────────────────────────────────────────────
@@ -285,5 +288,222 @@ export async function fetchStreak(metric: string): Promise<StreakResult> {
 
   const startDate = count > 0 ? daysAgoDate(count - 1) : null;
   return { metric, current_streak: count, start_date: startDate };
+}
+
+// ─── Weekly Data ──────────────────────────────────────────
+
+export async function fetchWeekData(startDate: string): Promise<WeekData> {
+  const start = startDate;
+  const end = formatDate(addDays(new Date(start + "T00:00:00"), 6));
+
+  const [dailyRes, sleepRes, workoutsRes, mealsRes, fastingRes, pullupsRes] =
+    await Promise.all([
+      supabase.from("daily_entries").select("*").gte("date", start).lte("date", end).order("date"),
+      supabase.from("sleep").select("*").gte("date", start).lte("date", end).order("date"),
+      supabase.from("workouts").select("*").gte("date", start).lte("date", end).order("date").order("start_time", { ascending: true, nullsFirst: false }),
+      supabase.from("meals").select("*").gte("date", start).lte("date", end).order("date"),
+      supabase.from("fasting").select("*").gte("date", start).lte("date", end).order("date"),
+      supabase.from("pullups").select("*").gte("date", start).lte("date", end).order("date"),
+    ]);
+
+  const errors = [dailyRes, sleepRes, workoutsRes, mealsRes, fastingRes, pullupsRes]
+    .filter((r) => r.error)
+    .map((r) => r.error!.message);
+  if (errors.length > 0) throw new Error(`Failed to fetch week data: ${errors.join("; ")}`);
+
+  const daily = (dailyRes.data ?? []) as DailyEntryRow[];
+  const sleep = (sleepRes.data ?? []) as SleepRow[];
+  const workouts = (workoutsRes.data ?? []) as WorkoutRow[];
+  const meals = (mealsRes.data ?? []) as MealRow[];
+  const fasting = (fastingRes.data ?? []) as FastingRow[];
+  const pullups = (pullupsRes.data ?? []) as PullupsRow[];
+
+  // Index by date
+  const dailyByDate = new Map(daily.map((d) => [d.date, d]));
+  const sleepByDate = new Map(sleep.map((s) => [s.date, s]));
+  const fastingByDate = new Map(fasting.map((f) => [f.date, f]));
+  const pullupsByDate = new Map(pullups.map((p) => [p.date, p]));
+
+  const workoutsByDate = new Map<string, WorkoutRow[]>();
+  for (const w of workouts) {
+    const arr = workoutsByDate.get(w.date);
+    if (arr) arr.push(w); else workoutsByDate.set(w.date, [w]);
+  }
+
+  const mealTotalsByDate = new Map<string, { protein: number; calories: number }>();
+  for (const m of meals) {
+    let t = mealTotalsByDate.get(m.date);
+    if (!t) { t = { protein: 0, calories: 0 }; mealTotalsByDate.set(m.date, t); }
+    t.protein += m.protein_g ?? 0;
+    t.calories += m.calories ?? 0;
+  }
+
+  // Build per-day summaries
+  const days: DaySummary[] = [];
+  const startD = new Date(start + "T00:00:00");
+  for (let i = 0; i < 7; i++) {
+    const dateStr = formatDate(addDays(startD, i));
+    const d = dailyByDate.get(dateStr);
+    const s = sleepByDate.get(dateStr);
+    const f = fastingByDate.get(dateStr);
+    const p = pullupsByDate.get(dateStr);
+    const mt = mealTotalsByDate.get(dateStr);
+    days.push({
+      date: dateStr,
+      weight: d?.weight ?? null,
+      energy: d?.energy ?? null,
+      alcohol: d?.alcohol ?? null,
+      sleepHours: s?.hours ?? null,
+      ouraScore: s?.oura_score ?? null,
+      appleScore: s?.apple_score ?? null,
+      workouts: workoutsByDate.get(dateStr) ?? [],
+      totalProtein: mt ? mt.protein : null,
+      totalCalories: mt ? mt.calories : null,
+      fastingCompliant: f?.compliant ?? null,
+      pullups: p?.total_count ?? null,
+    });
+  }
+
+  // Summary aggregations
+  const weightValues: number[] = [];
+  let daysWith = 0;
+  let daysWithout = 0;
+  for (const d of daily) {
+    if (d.weight != null) weightValues.push(d.weight);
+    if (d.alcohol === true) daysWith++;
+    else if (d.alcohol === false) daysWithout++;
+  }
+  const weightFirst = weightValues.length > 0 ? weightValues[0] : null;
+  const weightLast = weightValues.length > 0 ? weightValues[weightValues.length - 1] : null;
+  const weightDelta = weightFirst != null && weightLast != null && weightValues.length >= 2 ? weightLast - weightFirst : null;
+
+  const sleepHours: number[] = [];
+  const ouraScores: number[] = [];
+  const appleScores: number[] = [];
+  for (const s of sleep) {
+    if (s.hours != null) sleepHours.push(s.hours);
+    if (s.oura_score != null) ouraScores.push(s.oura_score);
+    if (s.apple_score != null) appleScores.push(s.apple_score);
+  }
+
+  const workoutTypes = [...new Set(workouts.map((w) => w.type))];
+  const fastingCompliant = fasting.filter((f) => f.compliant === true).length;
+  const pullupTotal = pullups.reduce((sum, p) => sum + p.total_count, 0);
+  const mealDays = [...mealTotalsByDate.values()];
+
+  const allDates = new Set([
+    ...daily.map((d) => d.date), ...sleep.map((s) => s.date),
+    ...workouts.map((w) => w.date), ...meals.map((m) => m.date),
+    ...fasting.map((f) => f.date), ...pullups.map((p) => p.date),
+  ]);
+
+  return {
+    start,
+    end,
+    days,
+    summary: {
+      daysLogged: allDates.size,
+      weight: { first: weightFirst, last: weightLast, delta: weightDelta },
+      sleep: { avgHours: avg(sleepHours), avgOura: avg(ouraScores), avgApple: avg(appleScores) },
+      workouts: { total: workouts.length, types: workoutTypes },
+      meals: {
+        avgDailyProtein: mealDays.length > 0 ? avg(mealDays.map((d) => d.protein)) : null,
+        avgDailyCalories: mealDays.length > 0 ? avg(mealDays.map((d) => d.calories)) : null,
+      },
+      fasting: { compliantDays: fastingCompliant, totalDays: fasting.length },
+      alcohol: { daysWith, daysWithout },
+      pullups: { total: pullupTotal, days: pullups.length },
+    },
+  };
+}
+
+export async function fetchWeekSummaries(
+  gridStart: string,
+  gridEnd: string,
+): Promise<Map<string, WeekSummary>> {
+  const [workoutsRes, sleepRes, dailyRes, fastingRes] = await Promise.all([
+    supabase.from("workouts").select("*").gte("date", gridStart).lte("date", gridEnd),
+    supabase.from("sleep").select("*").gte("date", gridStart).lte("date", gridEnd),
+    supabase.from("daily_entries").select("*").gte("date", gridStart).lte("date", gridEnd).order("date"),
+    supabase.from("fasting").select("*").gte("date", gridStart).lte("date", gridEnd),
+  ]);
+
+  // If any query fails, return empty map (calendar still works)
+  if (workoutsRes.error || sleepRes.error || dailyRes.error || fastingRes.error) {
+    return new Map();
+  }
+
+  const workouts = (workoutsRes.data ?? []) as WorkoutRow[];
+  const sleep = (sleepRes.data ?? []) as SleepRow[];
+  const daily = (dailyRes.data ?? []) as DailyEntryRow[];
+  const fasting = (fastingRes.data ?? []) as FastingRow[];
+
+  // Helper: get Monday for a date string (cached)
+  const mondayCache = new Map<string, string>();
+  function mondayOf(dateStr: string): string {
+    let mon = mondayCache.get(dateStr);
+    if (!mon) {
+      mon = formatDate(getMonday(new Date(dateStr + "T00:00:00")));
+      mondayCache.set(dateStr, mon);
+    }
+    return mon;
+  }
+
+  const summaries = new Map<string, WeekSummary>();
+
+  function ensure(monday: string): WeekSummary {
+    let s = summaries.get(monday);
+    if (!s) {
+      s = { workoutCount: 0, avgSleepHours: null, weightDelta: null, fastingCompliant: 0, fastingTotal: 0 };
+      summaries.set(monday, s);
+    }
+    return s;
+  }
+
+  // Workouts
+  for (const w of workouts) {
+    ensure(mondayOf(w.date)).workoutCount++;
+  }
+
+  // Sleep — group hours by week for averaging
+  const sleepByWeek = new Map<string, number[]>();
+  for (const s of sleep) {
+    const mon = mondayOf(s.date);
+    if (s.hours != null) {
+      const arr = sleepByWeek.get(mon);
+      if (arr) arr.push(s.hours);
+      else sleepByWeek.set(mon, [s.hours]);
+    }
+    ensure(mon); // ensure week exists
+  }
+  for (const [mon, hours] of sleepByWeek) {
+    ensure(mon).avgSleepHours = avg(hours);
+  }
+
+  // Weight — first and last per week
+  const weightByWeek = new Map<string, number[]>();
+  for (const d of daily) {
+    if (d.weight != null) {
+      const mon = mondayOf(d.date);
+      const arr = weightByWeek.get(mon);
+      if (arr) arr.push(d.weight);
+      else weightByWeek.set(mon, [d.weight]);
+    }
+  }
+  for (const [mon, weights] of weightByWeek) {
+    if (weights.length >= 2) {
+      ensure(mon).weightDelta = weights[weights.length - 1] - weights[0];
+    }
+  }
+
+  // Fasting
+  for (const f of fasting) {
+    const mon = mondayOf(f.date);
+    const s = ensure(mon);
+    s.fastingTotal++;
+    if (f.compliant === true) s.fastingCompliant++;
+  }
+
+  return summaries;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -155,7 +155,46 @@ export type WorkoutType =
   | "indoor_cycle"
   | "other"
 
-export type ViewType = "calendar" | "daily" | "metrics";
+export type ViewType = "calendar" | "daily" | "metrics" | "weekly";
+
+export interface WeekSummary {
+  workoutCount: number;
+  avgSleepHours: number | null;
+  weightDelta: number | null;
+  fastingCompliant: number;
+  fastingTotal: number;
+}
+
+export interface DaySummary {
+  date: string;
+  weight: number | null;
+  energy: number | null;
+  alcohol: boolean | null;
+  sleepHours: number | null;
+  ouraScore: number | null;
+  appleScore: number | null;
+  workouts: WorkoutRow[];
+  totalProtein: number | null;
+  totalCalories: number | null;
+  fastingCompliant: boolean | null;
+  pullups: number | null;
+}
+
+export interface WeekData {
+  start: string;
+  end: string;
+  days: DaySummary[];
+  summary: {
+    daysLogged: number;
+    weight: { first: number | null; last: number | null; delta: number | null };
+    sleep: { avgHours: number | null; avgOura: number | null; avgApple: number | null };
+    workouts: { total: number; types: string[] };
+    meals: { avgDailyProtein: number | null; avgDailyCalories: number | null };
+    fasting: { compliantDays: number; totalDays: number };
+    alcohol: { daysWith: number; daysWithout: number };
+    pullups: { total: number; days: number };
+  };
+}
 
 export type CustomMetricRow = Database["public"]["Tables"]["custom_metrics"]["Row"];
 export type BloodPressureRow = Database["public"]["Tables"]["blood_pressure"]["Row"];


### PR DESCRIPTION
## Summary
- New dedicated weekly view with vertical day columns grid (7 days + summary column) showing vitals, sleep, workouts, nutrition, fasting, and pullups
- Expandable summary cards below the grid for workouts, nutrition, sleep, and highlights
- Calendar 8th column (WK) links to weekly view; nav bar includes Weekly tab
- New types (`DaySummary`, `WeekData`), queries (`fetchWeekData`, `fetchWeekSummaries`), shared `WorkoutTypeBadge` component, and `SHORT_DAYS` constant

Closes #15

## Test plan
- [ ] Open `?view=weekly` — verify vertical day columns render with data
- [ ] Click day header — navigates to daily view
- [ ] Click ← Calendar — returns to correct month
- [ ] Prev/next week navigation works, URL syncs to Monday
- [ ] Cross-month week (e.g. Mar 30–Apr 5) — day click navigates to correct month
- [ ] Summary cards expand/collapse with Details toggle
- [ ] Calendar WK column shows weekly summary and links to weekly view
- [ ] Mobile: grid scrolls horizontally, summary cards stack to single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)