### PR TITLE
Fix streak bug and add chart axis labels (#48, #50)

### DIFF
--- a/cli/src/commands/query.ts
+++ b/cli/src/commands/query.ts
@@ -339,13 +339,14 @@ interface StreakConfig {
   table: TableName;
   select: string;
   pass: (row: any) => boolean;
+  logged: (row: any) => boolean;
 }
 
 const STREAK_MAP: Record<StreakName, StreakConfig> = {
-  "alcohol-free": { table: "daily_entries", select: "date, alcohol", pass: (r) => r.alcohol === false },
-  fasting: { table: "fasting", select: "date, compliant", pass: (r) => r.compliant === true },
-  workout: { table: "workouts", select: "date", pass: () => true },
-  logging: { table: "daily_entries", select: "date", pass: () => true },
+  "alcohol-free": { table: "daily_entries", select: "date, alcohol", pass: (r) => r.alcohol === false, logged: (r) => r.alcohol != null },
+  fasting: { table: "fasting", select: "date, compliant", pass: (r) => r.compliant === true, logged: (r) => r.compliant != null },
+  workout: { table: "workouts", select: "date", pass: () => true, logged: () => true },
+  logging: { table: "daily_entries", select: "date", pass: () => true, logged: () => true },
 };
 
 export async function computeStreak(metric: string) {
@@ -375,15 +376,20 @@ export async function computeStreak(metric: string) {
 
   const earliest = rangeStart;
   let count = 0;
-  for (let i = 0; ; i++) {
+  let offset = 0;
+  // Skip today if not yet logged (no row, or relevant field still null)
+  const todayRow = rowsByDate.get(daysAgo(0));
+  if (!todayRow || !cfg.logged(todayRow)) offset = 1;
+
+  for (let i = offset; ; i++) {
     const d = daysAgo(i);
     if (d < earliest) break;
     const row = rowsByDate.get(d);
-    if (row && cfg.pass(row)) { count++; }
+    if (row && cfg.pass(row)) count++;
     else break;
   }
 
-  const startDate = count > 0 ? daysAgo(count - 1) : null;
+  const startDate = count > 0 ? daysAgo(count + offset - 1) : null;
   return { metric, current_streak: count, start_date: startDate, as_of: today };
 }
 

--- a/src/components/metrics/bp-card.tsx
+++ b/src/components/metrics/bp-card.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import SectionCard from "@/components/day-detail/section-card";
 import { Stat } from "@/components/day-detail/section-vitals";
 import Sparkline from "./sparkline";
+import ChartContainer from "./chart-container";
 import { formatNumber } from "@/lib/format";
 import type { TrendSummary } from "@/lib/queries";
 
@@ -35,18 +36,20 @@ export default function BPCard({ points, summaries }: BPCardProps) {
     <SectionCard title="Blood Pressure" accent="#ef4444" empty={empty}>
       {!empty && (
         <>
-          <div className="h-20 mb-3 relative">
-            {sysPoints.length > 0 && (
-              <div className="absolute inset-0">
-                <Sparkline points={sysPoints} color="#ef4444" fill={false} />
-              </div>
-            )}
-            {diaPoints.length > 0 && (
-              <div className="absolute inset-0">
-                <Sparkline points={diaPoints} color="#3b82f6" fill={false} />
-              </div>
-            )}
-          </div>
+          <ChartContainer points={points.map((p) => ({ date: p.date, value: p.systolic ?? p.diastolic ?? 0 }))}>
+            <div className="h-full relative">
+              {sysPoints.length > 0 && (
+                <div className="absolute inset-0">
+                  <Sparkline points={sysPoints} color="#ef4444" fill={false} />
+                </div>
+              )}
+              {diaPoints.length > 0 && (
+                <div className="absolute inset-0">
+                  <Sparkline points={diaPoints} color="#3b82f6" fill={false} />
+                </div>
+              )}
+            </div>
+          </ChartContainer>
           <div className="flex gap-3 mb-2">
             <div className="flex items-center gap-1.5">
               <div className="w-2 h-0.5 bg-[#ef4444] rounded" />

--- a/src/components/metrics/chart-container.tsx
+++ b/src/components/metrics/chart-container.tsx
@@ -1,0 +1,54 @@
+import { computeYRange } from "./sparkline";
+import { formatShortDate } from "@/lib/format";
+
+interface ChartContainerProps {
+  points: Array<{ date: string; value: number }>;
+  goalLine?: number;
+  yLabels?: boolean;
+  formatY?: (v: number) => string;
+  children: React.ReactNode;
+}
+
+export default function ChartContainer({
+  points,
+  goalLine,
+  yLabels = false,
+  formatY = (v) => v.toFixed(1),
+  children,
+}: ChartContainerProps) {
+  if (points.length === 0) return <>{children}</>;
+
+  const showXLabels = points.length >= 2;
+  const firstDate = points[0].date;
+  const lastDate = points[points.length - 1].date;
+
+  let yMinLabel: string | undefined;
+  let yMaxLabel: string | undefined;
+  if (yLabels) {
+    const values = points.map((p) => p.value);
+    if (goalLine != null) values.push(goalLine);
+    const { yMin, yMax } = computeYRange(values);
+    yMinLabel = formatY(yMin);
+    yMaxLabel = formatY(yMax);
+  }
+
+  return (
+    <div className="mb-3">
+      <div className="flex">
+        {yLabels && (
+          <div className="flex flex-col justify-between w-8 shrink-0 pr-1">
+            <span className="text-[9px] font-mono text-muted/60 text-right leading-none">{yMaxLabel}</span>
+            <span className="text-[9px] font-mono text-muted/60 text-right leading-none">{yMinLabel}</span>
+          </div>
+        )}
+        <div className="h-20 flex-1">{children}</div>
+      </div>
+      {showXLabels && (
+        <div className={`flex justify-between mt-0.5 ${yLabels ? "ml-8" : ""}`}>
+          <span className="text-[9px] font-mono text-muted/60">{formatShortDate(firstDate)}</span>
+          <span className="text-[9px] font-mono text-muted/60">{formatShortDate(lastDate)}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/metrics/metric-card.tsx
+++ b/src/components/metrics/metric-card.tsx
@@ -1,8 +1,11 @@
 import SectionCard from "@/components/day-detail/section-card";
 import { Stat } from "@/components/day-detail/section-vitals";
 import Sparkline from "./sparkline";
+import ChartContainer from "./chart-container";
 import { formatNumber } from "@/lib/format";
 import type { TrendSummary } from "@/lib/queries";
+
+const formatYNumber = (v: number) => formatNumber(v) ?? "";
 
 interface MetricCardProps {
   title: string;
@@ -29,14 +32,19 @@ export default function MetricCard({
     <SectionCard title={title} accent={accent} empty={empty}>
       {!empty && (
         <>
-          <div className="h-20 mb-3">
+          <ChartContainer
+            points={points}
+            goalLine={goalLine}
+            yLabels
+            formatY={formatYNumber}
+          >
             <Sparkline
               points={points}
               color={accent}
               goalLine={goalLine}
               goalColor={goalLine != null ? `${accent}44` : undefined}
             />
-          </div>
+          </ChartContainer>
           <div className="grid grid-cols-4 gap-2">
             <Stat label="Current" value={formatNumber(points[points.length - 1].value)} unit={unit} />
             <Stat label="Avg" value={formatNumber(summary.avg)} unit={unit} />

--- a/src/components/metrics/sleep-card.tsx
+++ b/src/components/metrics/sleep-card.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import SectionCard from "@/components/day-detail/section-card";
 import { Stat } from "@/components/day-detail/section-vitals";
 import Sparkline from "./sparkline";
+import ChartContainer from "./chart-container";
 import { formatNumber } from "@/lib/format";
 import type { TrendSummary } from "@/lib/queries";
 
@@ -36,18 +37,20 @@ export default function SleepCard({ points, summaries }: SleepCardProps) {
     <SectionCard title="Sleep" accent="#a855f7" empty={empty}>
       {!empty && (
         <>
-          <div className="h-20 mb-3 relative">
-            {ouraPoints.length > 0 && (
-              <div className="absolute inset-0">
-                <Sparkline points={ouraPoints} color="#a855f7" fill={false} />
-              </div>
-            )}
-            {applePoints.length > 0 && (
-              <div className="absolute inset-0">
-                <Sparkline points={applePoints} color="#3b82f6" fill={false} />
-              </div>
-            )}
-          </div>
+          <ChartContainer points={points.map((p) => ({ date: p.date, value: p.oura_score ?? p.apple_score ?? 0 }))}>
+            <div className="h-full relative">
+              {ouraPoints.length > 0 && (
+                <div className="absolute inset-0">
+                  <Sparkline points={ouraPoints} color="#a855f7" fill={false} />
+                </div>
+              )}
+              {applePoints.length > 0 && (
+                <div className="absolute inset-0">
+                  <Sparkline points={applePoints} color="#3b82f6" fill={false} />
+                </div>
+              )}
+            </div>
+          </ChartContainer>
           <div className="flex gap-3 mb-2">
             {ouraPoints.length > 0 && (
               <div className="flex items-center gap-1.5">

--- a/src/components/metrics/sparkline.tsx
+++ b/src/components/metrics/sparkline.tsx
@@ -1,5 +1,13 @@
 import { memo } from "react";
 
+export function computeYRange(values: number[]): { yMin: number; yMax: number } {
+  if (values.length === 0) return { yMin: 0, yMax: 1 };
+  let yMin = Math.min(...values);
+  let yMax = Math.max(...values);
+  const yRange = yMax - yMin || 1;
+  return { yMin: yMin - yRange * 0.1, yMax: yMax + yRange * 0.1 };
+}
+
 interface SparklinePoint {
   date: string;
   value: number;
@@ -33,13 +41,7 @@ function SparklineInner({
   // Compute y range including goal line
   const values = points.map((p) => p.value);
   if (goalLine != null) values.push(goalLine);
-  let yMin = Math.min(...values);
-  let yMax = Math.max(...values);
-
-  // Add 10% padding so lines don't touch edges
-  const yRange = yMax - yMin || 1;
-  yMin -= yRange * 0.1;
-  yMax += yRange * 0.1;
+  const { yMin, yMax } = computeYRange(values);
 
   // Map dates to x positions proportional to actual time gaps
   const times = points.map((p) => new Date(p.date + "T00:00:00").getTime());

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -2,3 +2,9 @@ export function formatNumber(v: number | null, decimals = 1): string | null {
   if (v == null) return null;
   return Number(v.toFixed(decimals)).toString();
 }
+
+export function formatShortDate(dateStr: string): string {
+  const [, m, d] = dateStr.split("-").map(Number);
+  const months = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+  return `${months[m - 1]} ${d}`;
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -242,11 +242,12 @@ interface StreakConfig {
   table: TableName;
   select: string;
   pass: (row: any) => boolean;
+  logged: (row: any) => boolean;
 }
 
 const STREAK_MAP: Record<string, StreakConfig> = {
-  "alcohol-free": { table: "daily_entries", select: "date, alcohol", pass: (r) => r.alcohol === false },
-  fasting: { table: "fasting", select: "date, compliant", pass: (r) => r.compliant === true },
+  "alcohol-free": { table: "daily_entries", select: "date, alcohol", pass: (r) => r.alcohol === false, logged: (r) => r.alcohol != null },
+  fasting: { table: "fasting", select: "date, compliant", pass: (r) => r.compliant === true, logged: (r) => r.compliant != null },
 };
 
 export interface StreakResult {
@@ -278,7 +279,12 @@ export async function fetchStreak(metric: string): Promise<StreakResult> {
   }
 
   let count = 0;
-  for (let i = 0; ; i++) {
+  let offset = 0;
+  // Skip today if not yet logged (no row, or relevant field still null)
+  const todayRow = rowsByDate.get(daysAgoDate(0));
+  if (!todayRow || !cfg.logged(todayRow)) offset = 1;
+
+  for (let i = offset; ; i++) {
     const d = daysAgoDate(i);
     if (d < rangeStart) break;
     const row = rowsByDate.get(d);
@@ -286,7 +292,7 @@ export async function fetchStreak(metric: string): Promise<StreakResult> {
     else break;
   }
 
-  const startDate = count > 0 ? daysAgoDate(count - 1) : null;
+  const startDate = count > 0 ? daysAgoDate(count + offset - 1) : null;
   return { metric, current_streak: count, start_date: startDate };
 }
 


### PR DESCRIPTION
## Summary
- **#48 Streak fix**: Skip today at start of iteration when not yet logged. Adds `logged` checker to distinguish null fields (partial daily entry) from explicit failures. Applied to both web (`src/lib/queries.ts`) and CLI (`cli/src/commands/query.ts`).
- **#50 Chart axis labels**: New `ChartContainer` wrapper renders X date labels (all metric cards) and optional Y min/max labels (single-series cards: weight, pullups, protein). Extract shared `computeYRange` from Sparkline.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 63/63 CLI tests pass
- [ ] Open `?view=metrics` — verify date labels on all charts, Y labels on weight/pullups/protein
- [ ] Toggle 7D/14D/30D/90D — labels update
- [ ] Streak cards show actual count, not 0, when today not yet logged

Closes #48, closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)