### PR TITLE
Improve e2e test coverage

### DIFF
--- a/e2e/day-detail.spec.ts
+++ b/e2e/day-detail.spec.ts
@@ -99,6 +99,40 @@ test.describe("Day Detail View", () => {
     await expect(firstBadge).toContainText("PR");
   });
 
+  test("prev/next day navigation updates URL and content", async ({ page }) => {
+    await page.goto(`/?view=daily&date=${TEST_DATE}`);
+    await page.waitForSelector("[data-testid=day-detail]");
+
+    // Navigate to previous day
+    await page.getByRole("button", { name: "Previous day" }).click();
+    await expect(page).toHaveURL(/date=2098-12-31/);
+    await page.waitForSelector("[data-testid=day-detail]");
+
+    // Previous day has no data — should show "Not logged"
+    await expect(page.getByText("Not logged").first()).toBeVisible();
+
+    // Navigate forward twice to get back to test date + 1 (empty date)
+    await page.getByRole("button", { name: "Next day" }).click();
+    await expect(page).toHaveURL(new RegExp(`date=${TEST_DATE}`));
+    await page.waitForSelector("[data-testid=day-detail]");
+
+    // Back on test date — seeded data should be visible
+    await expect(page.locator("[data-testid=section-vitals]")).toContainText("175.5");
+  });
+
+  test("streak badges display on seeded date", async ({ page }) => {
+    await page.goto(`/?view=daily&date=${TEST_DATE}`);
+    await page.waitForSelector("[data-testid=day-detail]");
+
+    // The seeded date has fasting compliant + no alcohol + workout + logging data
+    // At minimum, the logging streak badge should appear (1 day of data)
+    // Check for any streak badge text patterns
+    const badges = page.locator(".rounded-full.bg-accent\\/10");
+    const count = await badges.count();
+    // At least the logging streak should appear for the seeded date
+    expect(count).toBeGreaterThan(0);
+  });
+
   test("empty date shows 'Not logged' for empty sections", async ({ page }) => {
     await page.goto(`/?view=daily&date=${TEST_DATE_EMPTY}`);
     await page.waitForSelector("[data-testid=day-detail]");

--- a/e2e/metrics.spec.ts
+++ b/e2e/metrics.spec.ts
@@ -49,6 +49,21 @@ test.describe("Metrics Dashboard", () => {
     expect(bestCount + longestCount).toBeGreaterThan(0);
   });
 
+  test("metric cards render sparkline charts", async ({ page }) => {
+    await page.goto("/?view=metrics");
+    await page.waitForSelector("[data-testid=metrics-dashboard]");
+
+    // Each metric card with data should render an SVG sparkline
+    const sparklines = page.locator("svg[role=img][aria-label='Sparkline chart']");
+    const count = await sparklines.count();
+    // At least weight and pullups should have data to chart
+    expect(count).toBeGreaterThan(0);
+
+    // Verify SVG contains path elements (the trend line)
+    const firstSparkline = sparklines.first();
+    await expect(firstSparkline.locator("path").first()).toBeVisible();
+  });
+
   test("range selector switches between periods", async ({ page }) => {
     await page.goto("/?view=metrics");
     await page.waitForSelector("[data-testid=metrics-dashboard]");

--- a/e2e/weekly.spec.ts
+++ b/e2e/weekly.spec.ts
@@ -23,4 +23,44 @@ test.describe("Weekly View", () => {
     await page.getByLabel("Next week").click();
     await expect(page).toHaveURL(/date=2098-12-29/);
   });
+
+  test("summary cards show aggregated data from seeded day", async ({ page }) => {
+    await page.goto(`/?view=weekly&date=${TEST_DATE}`);
+    await page.waitForSelector("[data-testid=weekly-view]");
+
+    // Workouts card: should show 2 workouts total
+    const workouts = page.locator("[data-testid=section-workouts]");
+    await expect(workouts).toBeVisible();
+    await expect(workouts).toContainText("2");
+
+    // Nutrition card: avg protein from seeded meals (40 + 35 = 75g)
+    const nutrition = page.locator("[data-testid=section-nutrition]");
+    await expect(nutrition).toBeVisible();
+    await expect(nutrition).toContainText("75");
+
+    // Sleep card: avg hours from seeded sleep (7.5h)
+    const sleep = page.locator("[data-testid=section-sleep]");
+    await expect(sleep).toBeVisible();
+    await expect(sleep).toContainText("7.5");
+
+    // Highlights card: pullups total (18)
+    const highlights = page.locator("[data-testid=section-highlights]");
+    await expect(highlights).toBeVisible();
+    await expect(highlights).toContainText("18");
+  });
+
+  test("grid shows seeded values in the Thursday column", async ({ page }) => {
+    await page.goto(`/?view=weekly&date=${TEST_DATE}`);
+    await page.waitForSelector("[data-testid=weekly-view]");
+
+    // Seeded date is Thursday (2099-01-01)
+    // Weight should appear in the grid
+    await expect(page.getByText("175.5").first()).toBeVisible();
+
+    // Sleep hours
+    await expect(page.getByText("7.5").first()).toBeVisible();
+
+    // Fasting compliance checkmark
+    await expect(page.getByText("✓").first()).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds 5 new e2e tests covering previously untested UI features
- Day detail: prev/next navigation updates URL and renders correct content
- Day detail: streak badges appear on dates with active streaks
- Metrics dashboard: sparkline SVG charts render with path elements
- Weekly view: summary cards show aggregated data (workouts, nutrition, sleep, pullups)
- Weekly view: grid cells show seeded values in correct day column

Coverage: 20 → 25 tests

closes #72

## Test plan
- [x] All 25 e2e tests pass (`npx playwright test`)
- [x] No changes to production code (test-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)