### PR TITLE
Add weekly planning & visualization

### DIFF
--- a/cli/src/commands/log.ts
+++ b/cli/src/commands/log.ts
@@ -32,6 +32,8 @@ export async function logWorkout(date: string, type: string, fields: { duration_
   await ensureDailyEntry(date);
   const normalized = {
     ...fields,
+    planned: fields.planned ?? null,
+    completed: fields.completed ?? null,
     start_time: fields.start_time ? parseTimestamp(date, fields.start_time) : undefined,
     end_time: fields.end_time ? parseTimestamp(date, fields.end_time) : undefined,
     source: fields.source ?? "manual",

--- a/cli/src/commands/plan.ts
+++ b/cli/src/commands/plan.ts
@@ -1,0 +1,366 @@
+import { Command } from "commander";
+import { fail, success } from "../output.js";
+import { getSupabase, throwIfError } from "../db.js";
+import { todayDate } from "../lib/date.js";
+import { ensureDailyEntry } from "../lib/ensure-daily-entry.js";
+import { validateWorkoutType } from "../lib/workout-types.js";
+
+// ─── Types ──────────────────────────────────────────
+
+export interface PlannedWorkout {
+  type: string;
+  duration_min?: number;
+  notes?: string;
+}
+
+export interface WeeklyPlanSchedule {
+  [key: string]: PlannedWorkout[];
+}
+
+export interface WeeklyPlanTargets {
+  total_sessions?: number;
+  total_duration_min?: number;
+  by_type?: Record<string, { sessions?: number; duration_min?: number }>;
+}
+
+export interface WeeklyPlan {
+  id: string;
+  name: string;
+  active: boolean;
+  schedule: WeeklyPlanSchedule;
+  targets: WeeklyPlanTargets | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type WorkoutStatus = "scheduled" | "skipped" | "completed" | "unplanned";
+
+const DAYS_OF_WEEK = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"] as const;
+
+// ─── Core functions (used by CLI + MCP) ─────────────
+
+export async function setPlan(
+  schedule: WeeklyPlanSchedule,
+  opts: { name?: string; targets?: WeeklyPlanTargets } = {},
+): Promise<WeeklyPlan> {
+  const sb = getSupabase();
+
+  // Validate schedule keys are valid days of the week
+  const validDays = new Set<string>(DAYS_OF_WEEK);
+  const invalidKeys = Object.keys(schedule).filter((k) => !validDays.has(k));
+  if (invalidKeys.length > 0) {
+    throw new Error(`Invalid schedule keys: ${invalidKeys.join(", ")}. Must be: ${DAYS_OF_WEEK.join(", ")}`);
+  }
+
+  // Validate all unique workout types in schedule
+  const uniqueTypes = new Set(DAYS_OF_WEEK.flatMap((day) => (schedule[day] ?? []).map((w) => w.type)));
+  for (const type of uniqueTypes) {
+    await validateWorkoutType(type);
+  }
+
+  // Deactivate existing active plans
+  const { error: deactivateErr } = await sb.from("weekly_plan").update({ active: false } as any).eq("active", true);
+  if (deactivateErr) throw new Error(`Database error: ${deactivateErr.message}`);
+
+  // Insert new plan
+  const { data, error } = await sb
+    .from("weekly_plan")
+    .insert({
+      name: opts.name ?? "default",
+      active: true,
+      schedule: schedule as any,
+      targets: (opts.targets ?? null) as any,
+    } as any)
+    .select()
+    .single();
+
+  if (error) throw new Error(`Database error: ${error.message}`);
+  return data as unknown as WeeklyPlan;
+}
+
+export async function getPlan(): Promise<WeeklyPlan | null> {
+  const sb = getSupabase();
+  const { data, error } = await sb
+    .from("weekly_plan")
+    .select("*")
+    .eq("active", true)
+    .order("updated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) throw new Error(`Database error: ${error.message}`);
+  return data as unknown as WeeklyPlan | null;
+}
+
+export function getMondayOfWeek(dateStr?: string): string {
+  const d = dateStr ? new Date(dateStr + "T00:00:00") : new Date();
+  const day = d.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function addDaysStr(dateStr: string, n: number): string {
+  const d = new Date(dateStr + "T00:00:00");
+  d.setDate(d.getDate() + n);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function validateMonday(dateStr: string): void {
+  const d = new Date(dateStr + "T00:00:00");
+  if (d.getDay() !== 1) throw new Error(`week_start must be a Monday, got ${dateStr} (${["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"][d.getDay()]})`);
+}
+
+export async function instantiatePlan(weekStart?: string): Promise<{ created: number; skipped: number; week_start: string }> {
+  const plan = await getPlan();
+  if (!plan) throw new Error("No active weekly plan found. Set one with set_plan first.");
+
+  const monday = weekStart ?? getMondayOfWeek();
+  if (weekStart) validateMonday(weekStart);
+  const sb = getSupabase();
+
+  // Get existing planned workouts for the week
+  const weekEnd = addDaysStr(monday, 6);
+  const { data: existing, error: fetchErr } = await sb
+    .from("workouts")
+    .select("date, type, planned, completed")
+    .gte("date", monday)
+    .lte("date", weekEnd)
+    .eq("planned", true);
+
+  if (fetchErr) throw new Error(`Database error: ${fetchErr.message}`);
+
+  // Count all existing planned workouts per date:type (including completed) for idempotency
+  const existingCounts = new Map<string, number>();
+  for (const w of (existing ?? []) as any[]) {
+    const key = `${w.date}:${w.type}`;
+    existingCounts.set(key, (existingCounts.get(key) ?? 0) + 1);
+  }
+
+  let created = 0;
+  let skipped = 0;
+  const ensuredDates = new Set<string>();
+
+  for (let i = 0; i < 7; i++) {
+    const dateStr = addDaysStr(monday, i);
+    const dayName = DAYS_OF_WEEK[i];
+    const planned = plan.schedule[dayName] ?? [];
+
+    // Count how many of each type are planned for this day
+    const neededCounts = new Map<string, number>();
+    for (const pw of planned) {
+      neededCounts.set(pw.type, (neededCounts.get(pw.type) ?? 0) + 1);
+    }
+
+    for (const pw of planned) {
+      const key = `${dateStr}:${pw.type}`;
+      const existingCount = existingCounts.get(key) ?? 0;
+      const neededCount = neededCounts.get(pw.type) ?? 0;
+
+      if (existingCount >= neededCount) {
+        skipped++;
+        continue;
+      }
+
+      // Ensure daily entry once per date (FK constraint requires it)
+      if (!ensuredDates.has(dateStr)) {
+        await ensureDailyEntry(dateStr);
+        ensuredDates.add(dateStr);
+      }
+      const { error: insertErr } = await sb
+        .from("workouts")
+        .insert({
+          date: dateStr,
+          type: pw.type,
+          duration_min: pw.duration_min ?? null,
+          notes: pw.notes ?? null,
+          planned: true,
+          completed: false,
+          source: "plan",
+        } as any);
+
+      if (insertErr) throw new Error(`Database error: ${insertErr.message}`);
+      existingCounts.set(key, existingCount + 1);
+      created++;
+    }
+  }
+
+  return { created, skipped, week_start: monday };
+}
+
+export async function queryPlanStatus(weekStart?: string, existingPlan?: WeeklyPlan | null) {
+  const plan = existingPlan !== undefined ? existingPlan : await getPlan();
+  const monday = weekStart ?? getMondayOfWeek();
+  if (weekStart) validateMonday(weekStart);
+  const weekEnd = addDaysStr(monday, 6);
+  const today = todayDate();
+  const sb = getSupabase();
+
+  // Fetch all workouts for the week
+  const { data: workouts, error } = await sb
+    .from("workouts")
+    .select("*")
+    .gte("date", monday)
+    .lte("date", weekEnd)
+    .order("date")
+    .order("start_time", { ascending: true, nullsFirst: false })
+    .order("created_at");
+
+  if (error) throw new Error(`Database error: ${error.message}`);
+  const allWorkouts = (workouts ?? []) as any[];
+
+  const days = [];
+  for (let i = 0; i < 7; i++) {
+    const dateStr = addDaysStr(monday, i);
+    const dayName = DAYS_OF_WEEK[i];
+    const dayWorkouts = allWorkouts.filter((w) => w.date === dateStr);
+
+    // Split: all planned rows (including completed-in-place) vs non-planned actuals
+    const allPlannedRows = dayWorkouts.filter((w) => w.planned === true);
+    const nonPlannedActual = dayWorkouts.filter((w) => w.planned !== true);
+
+    // Match planned to actuals one-to-one by type (supports duplicate types)
+    // A planned row completed in-place (completed=true) counts as its own match
+    const matchedActualIds = new Set<string>();
+    const planned = allPlannedRows.map((pw) => {
+      // Completed in-place — the planned row itself was marked completed
+      if (pw.completed === true) {
+        return { type: pw.type, duration_min: pw.duration_min, notes: pw.notes, status: "completed" as WorkoutStatus };
+      }
+      // Still pending — look for a matching non-planned actual
+      const match = nonPlannedActual.find((a) => a.type === pw.type && !matchedActualIds.has(a.id));
+      if (match) matchedActualIds.add(match.id);
+      const isSkipped = !match && dateStr < today;
+      const status: WorkoutStatus = match ? "completed" : isSkipped ? "skipped" : "scheduled";
+      return { type: pw.type, duration_min: pw.duration_min, notes: pw.notes, status };
+    });
+
+    const unplanned = nonPlannedActual.filter((a) => !matchedActualIds.has(a.id)).map((a) => ({
+      type: a.type,
+      duration_min: a.duration_min,
+      id: a.id,
+    }));
+
+    const matchedActual = nonPlannedActual.filter((a) => matchedActualIds.has(a.id)).map((a) => ({
+      type: a.type,
+      duration_min: a.duration_min,
+      id: a.id,
+    }));
+
+    days.push({
+      date: dateStr,
+      day: dayName,
+      planned,
+      actual: matchedActual,
+      unplanned,
+    });
+  }
+
+  // Compute targets
+  let targets = null;
+  if (plan?.targets) {
+    const completedWorkouts = allWorkouts.filter((w) => !(w.planned === true && w.completed === false));
+    const totalActual = completedWorkouts.length;
+    const totalDuration = completedWorkouts.reduce((s, w) => s + (w.duration_min ?? 0), 0);
+
+    targets = {
+      total_sessions: plan.targets.total_sessions != null
+        ? { target: plan.targets.total_sessions, actual: totalActual, remaining: Math.max(0, plan.targets.total_sessions - totalActual) }
+        : undefined,
+      total_duration_min: plan.targets.total_duration_min != null
+        ? { target: plan.targets.total_duration_min, actual: totalDuration, remaining: Math.max(0, plan.targets.total_duration_min - totalDuration) }
+        : undefined,
+      by_type: plan.targets.by_type
+        ? Object.fromEntries(
+            Object.entries(plan.targets.by_type).map(([type, t]) => {
+              const typeWorkouts = completedWorkouts.filter((w) => w.type === type);
+              return [type, {
+                sessions: t.sessions != null
+                  ? { target: t.sessions, actual: typeWorkouts.length }
+                  : undefined,
+                duration_min: t.duration_min != null
+                  ? { target: t.duration_min, actual: typeWorkouts.reduce((s: number, w: any) => s + (w.duration_min ?? 0), 0) }
+                  : undefined,
+              }];
+            }),
+          )
+        : undefined,
+    };
+  }
+
+  // Summary
+  const allPlanned = days.flatMap((d) => d.planned);
+  const summary = {
+    planned: allPlanned.length,
+    completed: allPlanned.filter((p) => p.status === "completed").length,
+    skipped: allPlanned.filter((p) => p.status === "skipped").length,
+    remaining: allPlanned.filter((p) => p.status === "scheduled").length,
+  };
+
+  return {
+    week_start: monday,
+    template: plan?.schedule ?? null,
+    days,
+    targets,
+    summary,
+  };
+}
+
+// ─── CLI registration ────────────────────────────────
+
+export function registerPlanCommands(program: Command): void {
+  const plan = program
+    .command("plan")
+    .description("Manage weekly training plan");
+
+  plan
+    .command("show")
+    .description("Show active plan template")
+    .action(async () => {
+      try {
+        const p = await getPlan();
+        if (!p) return success({ message: "No active plan" });
+        success(p);
+      } catch (e: any) { fail(e.message ?? String(e)); }
+    });
+
+  plan
+    .command("set")
+    .description("Set weekly plan")
+    .requiredOption("--schedule <json>", "Schedule JSON")
+    .option("--name <name>", "Plan name")
+    .option("--targets <json>", "Targets JSON")
+    .action(async (opts) => {
+      try {
+        const schedule = JSON.parse(opts.schedule);
+        const targets = opts.targets ? JSON.parse(opts.targets) : undefined;
+        success(await setPlan(schedule, { name: opts.name, targets }));
+      } catch (e: any) { fail(e.message ?? String(e)); }
+    });
+
+  plan
+    .command("instantiate")
+    .description("Create planned workout rows for a week")
+    .option("--week <date>", "Week start (Monday, YYYY-MM-DD)")
+    .action(async (opts) => {
+      try {
+        success(await instantiatePlan(opts.week));
+      } catch (e: any) { fail(e.message ?? String(e)); }
+    });
+
+  plan
+    .command("status")
+    .description("Show plan-vs-actual for a week")
+    .option("--week <date>", "Week start (Monday, YYYY-MM-DD)")
+    .action(async (opts) => {
+      try {
+        success(await queryPlanStatus(opts.week));
+      } catch (e: any) { fail(e.message ?? String(e)); }
+    });
+}

--- a/cli/src/commands/query.ts
+++ b/cli/src/commands/query.ts
@@ -5,6 +5,7 @@ import { todayDate, daysAgo, parseDate, daysBeforeDate } from "../lib/date.js";
 import { parseNum } from "../lib/parse.js";
 import { dayUrl, calendarUrl } from "../lib/urls.js";
 import { scanStreaks, computeDailySumMax } from "../lib/streak-helpers.js";
+import { getPlan, queryPlanStatus, getMondayOfWeek } from "./plan.js";
 import type { Database } from "../types/database.js";
 
 type TableName = keyof Database["public"]["Tables"];
@@ -37,6 +38,44 @@ export async function fetchDay(date: string) {
   results.forEach(throwIfError);
   const [daily, sleep, fasting, bp, workouts, meals, pullups, supplements, bodycomp, customMetrics] = results;
 
+  // Include plan context if active plan exists
+  let today_plan = undefined;
+  let week_progress = undefined;
+  try {
+    const plan = await getPlan();
+    if (plan) {
+      const dayOfWeek = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
+      const d = new Date(date + "T00:00:00");
+      const dayName = dayOfWeek[d.getDay()];
+      const daySchedule = plan.schedule[dayName] ?? [];
+
+      if (daySchedule.length > 0) {
+        const allWorkouts = (workouts.data ?? []) as any[];
+        const completedPlanned = allWorkouts.filter((w: any) => w.planned === true && w.completed === true);
+        const nonPlannedActual = allWorkouts.filter((w: any) => w.planned !== true);
+        const matchedIds = new Set<string>();
+        today_plan = daySchedule.map((pw: any) => {
+          // Check completed-in-place first, then non-planned actuals
+          const inPlace = completedPlanned.find((a: any) => a.type === pw.type && !matchedIds.has(a.id));
+          if (inPlace) { matchedIds.add(inPlace.id); return { ...pw, status: "completed" }; }
+          const match = nonPlannedActual.find((a: any) => a.type === pw.type && !matchedIds.has(a.id));
+          if (match) matchedIds.add(match.id);
+          return {
+            ...pw,
+            status: match ? "completed" : (date < todayDate() ? "skipped" : "scheduled"),
+          };
+        });
+      }
+
+      // Get week progress for the queried date's week (not necessarily current week)
+      const weekStart = getMondayOfWeek(date);
+      const planStatus = await queryPlanStatus(weekStart, plan);
+      week_progress = planStatus.summary;
+    }
+  } catch {
+    // Plan features are optional — don't fail the whole query
+  }
+
   return {
     date,
     dashboard_url: dayUrl(date),
@@ -50,6 +89,8 @@ export async function fetchDay(date: string) {
     supplements: supplements.data ?? null,
     body_composition: bodycomp.data ?? null,
     custom_metrics: customMetrics.data ?? [],
+    ...(today_plan ? { today_plan } : {}),
+    ...(week_progress ? { week_progress } : {}),
   };
 }
 
@@ -141,6 +182,17 @@ export async function fetchWeek() {
     };
   }
 
+  // Include plan status if active plan exists
+  let plan_status = undefined;
+  try {
+    const plan = await getPlan();
+    if (plan) {
+      plan_status = await queryPlanStatus(undefined, plan);
+    }
+  } catch {
+    // Plan features are optional
+  }
+
   return {
     start,
     end,
@@ -179,6 +231,7 @@ export async function fetchWeek() {
       days: pullupRows.length,
     },
     custom_metrics: customMetricsSummary,
+    ...(plan_status ? { plan_status } : {}),
   };
 }
 

--- a/cli/src/db.ts
+++ b/cli/src/db.ts
@@ -26,7 +26,7 @@ export function getSupabase(): SupabaseClient<Database> {
   return _client;
 }
 
-type TableName = Exclude<keyof Database["public"]["Tables"], "workout_types">;
+type TableName = Exclude<keyof Database["public"]["Tables"], "workout_types" | "weekly_plan">;
 
 export function throwIfError({ error }: { error: any }) {
   if (error) throw new Error(`Database error: ${error.message}`);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -3,6 +3,7 @@
 import { Command } from "commander";
 import { registerLogCommands } from "./commands/log.js";
 import { registerQueryCommands } from "./commands/query.js";
+import { registerPlanCommands } from "./commands/plan.js";
 
 const program = new Command();
 
@@ -13,5 +14,6 @@ program
 
 registerLogCommands(program);
 registerQueryCommands(program);
+registerPlanCommands(program);
 
 program.parseAsync();

--- a/cli/src/mcp.ts
+++ b/cli/src/mcp.ts
@@ -8,6 +8,7 @@ import { getWorkoutTypes } from "./lib/workout-types.js";
 import { deleteRowById } from "./db.js";
 import { todayDate } from "./lib/date.js";
 import { dayUrl, calendarUrl } from "./lib/urls.js";
+import { setPlan, getPlan, instantiatePlan, queryPlanStatus } from "./commands/plan.js";
 
 const server = new McpServer({ name: "ironcompass", version: "0.1.0" });
 
@@ -281,6 +282,60 @@ server.registerTool("ironcompass_delete_workout", {
 }, async ({ id }) => {
   const deleted = await deleteRowById("workouts", id);
   return textResult({ deleted, dashboard_url: dayUrl(deleted.date) });
+});
+
+// --- Plan tools ---
+
+server.registerTool("ironcompass_set_plan", {
+  title: "Set Weekly Plan",
+  description: "Set or replace the active weekly training plan template with schedule and optional targets",
+  inputSchema: z.object({
+    name: z.string().optional().describe("Plan name (default: 'default')"),
+    schedule: z.record(z.string(), z.array(z.object({
+      type: z.string(),
+      duration_min: z.number().optional(),
+      notes: z.string().optional(),
+    }))).describe("Schedule: keys are days of week (monday-sunday), values are arrays of planned workouts"),
+    targets: z.object({
+      total_sessions: z.number().optional().describe("Target total workout sessions per week"),
+      total_duration_min: z.number().optional().describe("Target total workout minutes per week"),
+      by_type: z.record(z.string(), z.object({
+        sessions: z.number().optional(),
+        duration_min: z.number().optional(),
+      })).optional().describe("Per-type targets"),
+    }).optional().describe("Weekly targets"),
+  }),
+}, async ({ name, schedule, targets }) => {
+  return textResult(await setPlan(schedule as any, { name, targets: targets as any }));
+});
+
+server.registerTool("ironcompass_get_plan", {
+  title: "Get Weekly Plan",
+  description: "Get the active weekly training plan template",
+  inputSchema: z.object({}),
+}, async () => {
+  const plan = await getPlan();
+  return textResult(plan ?? { message: "No active plan" });
+});
+
+server.registerTool("ironcompass_instantiate_plan", {
+  title: "Instantiate Plan",
+  description: "Create planned workout rows for a specific week from the active plan template. Idempotent — skips dates that already have planned workouts.",
+  inputSchema: z.object({
+    week_start: z.string().optional().describe("Monday of the week (YYYY-MM-DD). Defaults to current week."),
+  }),
+}, async ({ week_start }) => {
+  return textResult(await instantiatePlan(week_start ?? undefined));
+});
+
+server.registerTool("ironcompass_query_plan", {
+  title: "Plan Status",
+  description: "Get plan-vs-actual workout status for a week, including target progress",
+  inputSchema: z.object({
+    week_start: z.string().optional().describe("Monday of the week (YYYY-MM-DD). Defaults to current week."),
+  }),
+}, async ({ week_start }) => {
+  return textResult(await queryPlanStatus(week_start ?? undefined));
 });
 
 const transport = new StdioServerTransport();

--- a/cli/src/types/database.ts
+++ b/cli/src/types/database.ts
@@ -375,6 +375,36 @@ export type Database = {
           },
         ]
       }
+      weekly_plan: {
+        Row: {
+          id: string
+          name: string
+          active: boolean
+          schedule: Record<string, unknown>
+          targets: Record<string, unknown> | null
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          id?: string
+          name?: string
+          active?: boolean
+          schedule: Record<string, unknown>
+          targets?: Record<string, unknown> | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          id?: string
+          name?: string
+          active?: boolean
+          schedule?: Record<string, unknown>
+          targets?: Record<string, unknown> | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
       workout_types: {
         Row: {
           name: string

--- a/cli/test/cli.test.ts
+++ b/cli/test/cli.test.ts
@@ -188,6 +188,28 @@ describe("ironcompass CLI", () => {
     assert.ok(parsed.error.includes("not a real calendar date"));
   });
 
+  // plan commands
+  it("plan --help lists subcommands", () => {
+    const { stdout, exitCode } = run("plan", "--help");
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.includes("show"), "missing show subcommand");
+    assert.ok(stdout.includes("set"), "missing set subcommand");
+    assert.ok(stdout.includes("instantiate"), "missing instantiate subcommand");
+    assert.ok(stdout.includes("status"), "missing status subcommand");
+  });
+
+  it("plan set --help shows --schedule option", () => {
+    const { stdout, exitCode } = run("plan", "set", "--help");
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.includes("--schedule"), "missing --schedule option");
+  });
+
+  it("plan status --help shows --week option", () => {
+    const { stdout, exitCode } = run("plan", "status", "--help");
+    assert.equal(exitCode, 0);
+    assert.ok(stdout.includes("--week"), "missing --week option");
+  });
+
   // empty supplements rejected
   it("log supplements --taken ',' fails with empty list error", () => {
     const { stderr, exitCode } = run("log", "supplements", "--taken", ",");

--- a/cli/test/mcp.test.ts
+++ b/cli/test/mcp.test.ts
@@ -69,6 +69,10 @@ const EXPECTED_TOOLS = [
   "ironcompass_delete_metric",
   "ironcompass_delete_meal",
   "ironcompass_delete_workout",
+  "ironcompass_set_plan",
+  "ironcompass_get_plan",
+  "ironcompass_instantiate_plan",
+  "ironcompass_query_plan",
 ];
 
 describe("ironcompass MCP server", () => {
@@ -98,7 +102,7 @@ describe("ironcompass MCP server", () => {
     }
   });
 
-  it("lists all 19 tools with correct schemas", async () => {
+  it("lists all 23 tools with correct schemas", async () => {
     const proc = spawnMcp();
     try {
       const response = await initAndSend(proc, {
@@ -111,8 +115,8 @@ describe("ironcompass MCP server", () => {
       assert.ok(response.result, "Expected result");
       const tools = response.result.tools;
 
-      // All 19 tools present
-      assert.equal(tools.length, 19);
+      // All 23 tools present
+      assert.equal(tools.length, 23);
       const names = tools.map((t: any) => t.name).sort();
       assert.deepEqual(names, [...EXPECTED_TOOLS].sort());
 

--- a/cli/test/unit.test.ts
+++ b/cli/test/unit.test.ts
@@ -4,6 +4,7 @@ import { parseNum, parseList, sparse } from "../src/lib/parse.ts";
 import { todayDate, daysAgo, parseDate, daysBeforeDate } from "../src/lib/date.ts";
 import { throwIfError } from "../src/db.ts";
 import { scanStreaks, computeMaxRecord, computeMinRecord, computeDailySumMax } from "../src/lib/streak-helpers.ts";
+import type { WorkoutStatus } from "../src/commands/plan.ts";
 
 describe("parseNum", () => {
   it("returns undefined for undefined input", () => {
@@ -342,5 +343,47 @@ describe("throwIfError", () => {
       () => throwIfError({ error: { message: "connection refused" } }),
       /Database error: connection refused/,
     );
+  });
+});
+
+// --- Workout status helper (pure logic, no DB) ---
+
+function getWorkoutStatus(w: { planned: boolean | null; completed: boolean | null; date: string }, today: string): WorkoutStatus {
+  const isPlannedOnly = w.planned === true && w.completed === false;
+  if (isPlannedOnly) {
+    return w.date < today ? "skipped" : "scheduled";
+  }
+  return "completed";
+}
+
+describe("getWorkoutStatus", () => {
+  const today = "2026-03-13";
+
+  it("planned=true, completed=false, future date => scheduled", () => {
+    assert.equal(getWorkoutStatus({ planned: true, completed: false, date: "2026-03-14" }, today), "scheduled");
+  });
+
+  it("planned=true, completed=false, today => scheduled", () => {
+    assert.equal(getWorkoutStatus({ planned: true, completed: false, date: "2026-03-13" }, today), "scheduled");
+  });
+
+  it("planned=true, completed=false, past date => skipped", () => {
+    assert.equal(getWorkoutStatus({ planned: true, completed: false, date: "2026-03-12" }, today), "skipped");
+  });
+
+  it("planned=null, completed=null => completed", () => {
+    assert.equal(getWorkoutStatus({ planned: null, completed: null, date: "2026-03-12" }, today), "completed");
+  });
+
+  it("planned=true, completed=true => completed", () => {
+    assert.equal(getWorkoutStatus({ planned: true, completed: true, date: "2026-03-12" }, today), "completed");
+  });
+
+  it("planned=true, completed=null => completed", () => {
+    assert.equal(getWorkoutStatus({ planned: true, completed: null, date: "2026-03-12" }, today), "completed");
+  });
+
+  it("planned=false, completed=null => completed", () => {
+    assert.equal(getWorkoutStatus({ planned: false, completed: null, date: "2026-03-12" }, today), "completed");
   });
 });

--- a/src/components/calendar/calendar-day.tsx
+++ b/src/components/calendar/calendar-day.tsx
@@ -1,4 +1,5 @@
 import type { WorkoutRow } from "@/lib/types";
+import { getWorkoutStatus, type WorkoutStatus } from "@/lib/workout-status";
 import { FALLBACK_COLOR } from "@/lib/workout-types";
 
 interface CalendarDayProps {
@@ -7,11 +8,36 @@ interface CalendarDayProps {
   colorMap: Record<string, string>;
   isCurrentMonth: boolean;
   isToday: boolean;
+  today: string;
   onClick: () => void;
 }
 
-function WorkoutDot({ type, colorMap }: { type: string; colorMap: Record<string, string> }) {
+function WorkoutDot({ type, colorMap, status }: { type: string; colorMap: Record<string, string>; status: WorkoutStatus }) {
   const color = colorMap[type] ?? FALLBACK_COLOR;
+
+  if (status === "skipped") {
+    return (
+      <span
+        className="w-2 h-2 rounded-full shrink-0 opacity-30"
+        style={{ backgroundColor: "#737373" }}
+      />
+    );
+  }
+
+  if (status === "scheduled") {
+    return (
+      <span
+        className="w-2 h-2 rounded-full shrink-0"
+        style={{
+          border: `1.5px solid ${color}`,
+          backgroundColor: "transparent",
+          boxShadow: `0 0 4px ${color}44`,
+        }}
+      />
+    );
+  }
+
+  // completed or unplanned
   return (
     <span
       className="w-2 h-2 rounded-full shrink-0"
@@ -29,13 +55,21 @@ export default function CalendarDay({
   colorMap,
   isCurrentMonth,
   isToday,
+  today,
   onClick,
 }: CalendarDayProps) {
   const day = date.getDate();
   const dateStr = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-  const isRest = isCurrentMonth && workouts.length === 0;
-  const showOverflow = workouts.length > 3;
-  const visibleWorkouts = workouts.slice(0, showOverflow ? 2 : 3);
+
+  // Filter: for display purposes, separate completed/actual from planned-only
+  const completedWorkouts = workouts.filter((w) => !(w.planned === true && w.completed === false));
+  const plannedOnlyWorkouts = workouts.filter((w) => w.planned === true && w.completed === false);
+
+  // Show completed first, then planned-only
+  const orderedWorkouts = [...completedWorkouts, ...plannedOnlyWorkouts];
+  const isRest = isCurrentMonth && orderedWorkouts.length === 0;
+  const showOverflow = orderedWorkouts.length > 3;
+  const visibleWorkouts = orderedWorkouts.slice(0, showOverflow ? 2 : 3);
 
   return (
     <button
@@ -62,11 +96,11 @@ export default function CalendarDay({
 
       <div className="flex items-center gap-1 mt-auto pt-1">
         {visibleWorkouts.map((w) => (
-          <WorkoutDot key={w.id} type={w.type} colorMap={colorMap} />
+          <WorkoutDot key={w.id} type={w.type} colorMap={colorMap} status={getWorkoutStatus(w, today)} />
         ))}
         {showOverflow && (
           <span className="text-[9px] font-mono text-muted leading-none">
-            +{workouts.length - 2}
+            +{orderedWorkouts.length - 2}
           </span>
         )}
         {isRest && (

--- a/src/components/calendar/calendar-week-summary.tsx
+++ b/src/components/calendar/calendar-week-summary.tsx
@@ -18,8 +18,13 @@ export default function CalendarWeekSummary({ monday, month, summary }: Calendar
     >
       {summary ? (
         <>
-          {summary.workoutCount > 0 && (
-            <span className="text-xs font-mono font-bold text-accent">{summary.workoutCount}w</span>
+          {(summary.workoutCount > 0 || summary.plannedCount > 0) && (
+            <span className="text-xs font-mono font-bold text-accent">
+              {summary.plannedCount > 0
+                ? `${summary.workoutCount}/${summary.workoutCount + summary.plannedCount}w`
+                : `${summary.workoutCount}w`
+              }
+            </span>
           )}
           {summary.avgSleepHours != null && (
             <span className="text-[10px] font-mono text-purple-400">{summary.avgSleepHours.toFixed(1)}h</span>

--- a/src/components/calendar/calendar.tsx
+++ b/src/components/calendar/calendar.tsx
@@ -126,6 +126,7 @@ export default function Calendar({ initialMonth }: { initialMonth?: string } = {
   }, [workouts]);
 
   const today = useMemo(() => new Date(), []);
+  const todayStr = useMemo(() => formatDate(today), [today]);
 
   if (!currentMonth) {
     return <LoadingSkeleton />;
@@ -210,6 +211,7 @@ export default function Calendar({ initialMonth }: { initialMonth?: string } = {
                       colorMap={colorMap}
                       isCurrentMonth={date.getMonth() === currentMonth.getMonth()}
                       isToday={isSameDay(date, today)}
+                      today={todayStr}
                       onClick={() => router.push(`/?view=daily&date=${key}&month=${formatDate(currentMonth)}`)}
                     />
                   </div>

--- a/src/components/day-detail/day-detail.tsx
+++ b/src/components/day-detail/day-detail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { formatDate } from "@/lib/date";
 import { fetchDayData, fetchStreak, fetchPersonalRecords, type DayData, type StreakResult, type PersonalRecord } from "@/lib/queries";
 import { getWorkoutTypes, buildTypeLookup, type WorkoutTypeLookup } from "@/lib/workout-types";
 import DayHeader from "./day-header";
@@ -84,6 +85,7 @@ export default function DayDetail({ date, backMonth }: { date: string; backMonth
   const [typeLookup, setTypeLookup] = useState<WorkoutTypeLookup>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const today = useMemo(() => formatDate(new Date()), []);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -171,7 +173,7 @@ export default function DayDetail({ date, backMonth }: { date: string; backMonth
         <SectionFasting data={data!.fasting} />
         <SectionBP data={data!.bloodPressure} />
         <div className="col-span-full">
-          <SectionWorkouts data={data!.workouts} typeLookup={typeLookup} />
+          <SectionWorkouts data={data!.workouts} typeLookup={typeLookup} today={today} />
         </div>
         <div className="col-span-full">
           <SectionMeals data={data!.meals} />

--- a/src/components/day-detail/section-workouts.tsx
+++ b/src/components/day-detail/section-workouts.tsx
@@ -1,13 +1,34 @@
 import type { WorkoutRow } from "@/lib/types";
 import type { WorkoutTypeLookup } from "@/lib/workout-types";
 import { FALLBACK_COLOR } from "@/lib/workout-types";
+import { getWorkoutStatus, type WorkoutStatus } from "@/lib/workout-status";
 import { formatTime } from "@/lib/date";
 import SectionCard from "./section-card";
 import WorkoutTypeBadge from "@/components/ui/workout-type-badge";
 import WorkoutDetails from "./workout-details";
 
-function WorkoutCard({ workout, typeLookup }: { workout: WorkoutRow; typeLookup: WorkoutTypeLookup }) {
+function StatusBadge({ status }: { status: WorkoutStatus }) {
+  if (status === "completed" || status === "unplanned") return null;
+
+  if (status === "scheduled") {
+    return (
+      <span className="inline-block px-1.5 py-0.5 rounded text-[10px] font-mono text-blue-400 bg-blue-500/10 border border-blue-500/30">
+        Planned
+      </span>
+    );
+  }
+
+  // skipped
+  return (
+    <span className="inline-block px-1.5 py-0.5 rounded text-[10px] font-mono text-gray-400 bg-gray-500/10 border border-gray-500/30">
+      Skipped
+    </span>
+  );
+}
+
+function WorkoutCard({ workout, typeLookup, status }: { workout: WorkoutRow; typeLookup: WorkoutTypeLookup; status: WorkoutStatus }) {
   const info = typeLookup[workout.type];
+  const isSkipped = status === "skipped";
   const stats = [
     workout.duration_min != null && `${workout.duration_min} min`,
     workout.distance_mi != null && `${workout.distance_mi} mi`,
@@ -17,12 +38,15 @@ function WorkoutCard({ workout, typeLookup }: { workout: WorkoutRow; typeLookup:
   ].filter(Boolean);
 
   return (
-    <div className="flex flex-col gap-1.5 p-3 rounded-md bg-background/50 border border-border/50">
+    <div className={`flex flex-col gap-1.5 p-3 rounded-md bg-background/50 border border-border/50 ${isSkipped ? "opacity-50" : ""}`}>
       <div className="flex items-center gap-2">
         {workout.start_time && (
           <span className="text-xs font-mono text-muted">{formatTime(workout.start_time)}</span>
         )}
-        <WorkoutTypeBadge type={workout.type} color={info?.color} displayName={info?.displayName} />
+        <span className={isSkipped ? "line-through" : ""}>
+          <WorkoutTypeBadge type={workout.type} color={info?.color} displayName={info?.displayName} />
+        </span>
+        <StatusBadge status={status} />
         {workout.source && (
           <span className="inline-block px-1.5 py-0.5 rounded text-[10px] font-mono text-slate-400 bg-slate-800/50 border border-slate-700/50">
             {workout.source}
@@ -42,13 +66,18 @@ function WorkoutCard({ workout, typeLookup }: { workout: WorkoutRow; typeLookup:
   );
 }
 
-export default function SectionWorkouts({ data, typeLookup }: { data: WorkoutRow[]; typeLookup: WorkoutTypeLookup }) {
+export default function SectionWorkouts({ data, typeLookup, today }: { data: WorkoutRow[]; typeLookup: WorkoutTypeLookup; today: string }) {
+  // Compute status once per workout, then sort
+  const order: Record<WorkoutStatus, number> = { completed: 0, unplanned: 0, scheduled: 1, skipped: 2 };
+  const withStatus = data.map((w) => ({ workout: w, status: getWorkoutStatus(w, today) }));
+  withStatus.sort((a, b) => order[a.status] - order[b.status]);
+
   return (
     <SectionCard title="Workouts" accent="#3b82f6" empty={data.length === 0}>
-      {data.length > 0 && (
+      {withStatus.length > 0 && (
         <div className="space-y-2">
-          {data.map((w) => (
-            <WorkoutCard key={w.id} workout={w} typeLookup={typeLookup} />
+          {withStatus.map(({ workout, status }) => (
+            <WorkoutCard key={workout.id} workout={workout} typeLookup={typeLookup} status={status} />
           ))}
         </div>
       )}

--- a/src/components/weekly/plan-progress-card.tsx
+++ b/src/components/weekly/plan-progress-card.tsx
@@ -1,0 +1,80 @@
+import type { PlanStatusResult } from "@/lib/queries";
+import type { WorkoutTypeLookup } from "@/lib/workout-types";
+import { FALLBACK_COLOR } from "@/lib/workout-types";
+import SectionCard from "@/components/day-detail/section-card";
+
+function ProgressBar({ value, max, color }: { value: number; max: number; color: string }) {
+  const pct = max > 0 ? Math.min(100, (value / max) * 100) : 0;
+  return (
+    <div className="w-full h-1.5 bg-border rounded-full overflow-hidden">
+      <div
+        className="h-full rounded-full transition-all"
+        style={{ width: `${pct}%`, backgroundColor: color }}
+      />
+    </div>
+  );
+}
+
+export default function PlanProgressCard({ planStatus, typeLookup }: { planStatus: PlanStatusResult; typeLookup: WorkoutTypeLookup }) {
+  const { summary, targets } = planStatus;
+
+  return (
+    <SectionCard title="Plan Progress" accent="#3b82f6">
+      <div className="space-y-3">
+        {/* Overall sessions */}
+        <div>
+          <div className="flex items-baseline justify-between mb-1">
+            <span className="text-xs font-mono text-foreground">
+              {summary.completed}/{summary.planned} sessions
+            </span>
+            <span className="text-[10px] font-mono text-muted">
+              {summary.skipped > 0 && `${summary.skipped} skipped`}
+              {summary.skipped > 0 && summary.remaining > 0 && " / "}
+              {summary.remaining > 0 && `${summary.remaining} remaining`}
+            </span>
+          </div>
+          <ProgressBar value={summary.completed} max={summary.planned} color="#3b82f6" />
+        </div>
+
+        {/* Duration target */}
+        {targets?.total_duration_min && (
+          <div>
+            <div className="flex items-baseline justify-between mb-1">
+              <span className="text-xs font-mono text-foreground">
+                {targets.total_duration_min.actual}/{targets.total_duration_min.target} min
+              </span>
+              {targets.total_duration_min.remaining > 0 && (
+                <span className="text-[10px] font-mono text-muted">
+                  {targets.total_duration_min.remaining} remaining
+                </span>
+              )}
+            </div>
+            <ProgressBar value={targets.total_duration_min.actual} max={targets.total_duration_min.target} color="#22c55e" />
+          </div>
+        )}
+
+        {/* Per-type breakdown */}
+        {targets?.by_type && Object.keys(targets.by_type).length > 0 && (
+          <div className="border-t border-border pt-2 space-y-1.5">
+            {Object.entries(targets.by_type).map(([type, t]) => {
+              const color = typeLookup[type]?.color ?? FALLBACK_COLOR;
+              const displayName = typeLookup[type]?.displayName ?? type;
+              return (
+                <div key={type} className="flex items-center gap-2">
+                  <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
+                  <span className="text-[10px] font-mono text-foreground/80 w-20 truncate">{displayName}</span>
+                  {t.sessions && (
+                    <span className="text-[10px] font-mono text-muted">{t.sessions.actual}/{t.sessions.target}</span>
+                  )}
+                  {t.duration_min && (
+                    <span className="text-[10px] font-mono text-muted ml-1">{t.duration_min.actual}/{t.duration_min.target}m</span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/components/weekly/weekly-view.tsx
+++ b/src/components/weekly/weekly-view.tsx
@@ -4,10 +4,12 @@ import { useState, useEffect, useCallback, useMemo } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { getMonday, formatDate, addDays, parseDate, SHORT_DAYS } from "@/lib/date";
-import { fetchWeekData } from "@/lib/queries";
+import { fetchWeekData, fetchPlanStatus, type PlanStatusResult } from "@/lib/queries";
+import { getWorkoutStatus, type WorkoutStatus } from "@/lib/workout-status";
 import type { WeekData, DaySummary } from "@/lib/types";
 import { getWorkoutTypes, buildTypeLookup, FALLBACK_COLOR, type WorkoutTypeLookup } from "@/lib/workout-types";
 import WeeklyHeader from "./weekly-header";
+import PlanProgressCard from "./plan-progress-card";
 import SectionCard from "@/components/day-detail/section-card";
 import WorkoutTypeBadge from "@/components/ui/workout-type-badge";
 
@@ -27,6 +29,7 @@ export default function WeeklyView({ date, backMonth }: { date?: string; backMon
   const [monday, setMonday] = useState<Date | null>(null);
   const [hasNavigated, setHasNavigated] = useState(false);
   const [data, setData] = useState<WeekData | null>(null);
+  const [planStatus, setPlanStatus] = useState<PlanStatusResult | null>(null);
   const [typeLookup, setTypeLookup] = useState<WorkoutTypeLookup>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -61,10 +64,13 @@ export default function WeeklyView({ date, backMonth }: { date?: string; backMon
     setLoading(true);
     setError(null);
     try {
-      const result = await fetchWeekData(start);
-      if (!signal.aborted) { setData(result); setLoading(false); }
+      const [result, plan] = await Promise.all([
+        fetchWeekData(start),
+        fetchPlanStatus(start).catch(() => null),
+      ]);
+      if (!signal.aborted) { setData(result); setPlanStatus(plan); setLoading(false); }
     } catch (err) {
-      if (!signal.aborted) { setData(null); setError(err instanceof Error ? err.message : "Failed to load"); setLoading(false); }
+      if (!signal.aborted) { setData(null); setPlanStatus(null); setError(err instanceof Error ? err.message : "Failed to load"); setLoading(false); }
     }
   }, []);
 
@@ -153,11 +159,11 @@ export default function WeeklyView({ date, backMonth }: { date?: string; backMon
                             {section.label}
                           </div>
                         )}
-                        <DayCell section={section.key} day={day} typeLookup={typeLookup} />
+                        <DayCell section={section.key} day={day} typeLookup={typeLookup} today={today} />
                       </div>
                     ))}
                     <div className="bg-accent/[0.03] px-2 py-2 min-h-[3rem]">
-                      <SummaryCell section={section.key} summary={data.summary} typeLookup={typeLookup} />
+                      <SummaryCell section={section.key} summary={data.summary} typeLookup={typeLookup} planStatus={planStatus} />
                     </div>
                   </div>
                 ))}
@@ -167,7 +173,8 @@ export default function WeeklyView({ date, backMonth }: { date?: string; backMon
 
           {/* Summary cards */}
           <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4">
-            <WorkoutSectionCard data={data} typeLookup={typeLookup} />
+            {planStatus && <PlanProgressCard planStatus={planStatus} typeLookup={typeLookup} />}
+            <WorkoutSectionCard data={data} typeLookup={typeLookup} planStatus={planStatus} />
             <NutritionSectionCard data={data} />
             <SleepSectionCard data={data} />
             <HighlightsCard data={data} />
@@ -180,7 +187,7 @@ export default function WeeklyView({ date, backMonth }: { date?: string; backMon
 
 // ─── Grid Cells ──────────────────────────────────────
 
-function DayCell({ section, day, typeLookup }: { section: SectionKey; day: DaySummary; typeLookup: WorkoutTypeLookup }) {
+function DayCell({ section, day, typeLookup, today }: { section: SectionKey; day: DaySummary; typeLookup: WorkoutTypeLookup; today: string }) {
   switch (section) {
     case "vitals":
       if (day.weight == null && day.energy == null && day.alcohol == null)
@@ -209,13 +216,24 @@ function DayCell({ section, day, typeLookup }: { section: SectionKey; day: DaySu
       if (day.workouts.length === 0) return <Empty />;
       return (
         <div className="flex flex-col gap-1">
-          {day.workouts.map((w) => (
-            <div key={w.id} className="flex items-center gap-1">
-              <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: typeLookup[w.type]?.color ?? FALLBACK_COLOR }} />
-              <span className="text-[10px] font-mono text-foreground/80 truncate">{typeLookup[w.type]?.displayName ?? w.type}</span>
-              {w.duration_min != null && <span className="text-[10px] font-mono text-muted">{w.duration_min}m</span>}
-            </div>
-          ))}
+          {day.workouts.map((w) => {
+            const status = getWorkoutStatus(w, today);
+            const isPlannedOnly = status === "scheduled" || status === "skipped";
+            const isSkipped = status === "skipped";
+            return (
+              <div key={w.id} className={`flex items-center gap-1 ${isSkipped ? "opacity-40 line-through" : ""}`}>
+                <span
+                  className="w-1.5 h-1.5 rounded-full shrink-0"
+                  style={isPlannedOnly && !isSkipped
+                    ? { border: `1px solid ${typeLookup[w.type]?.color ?? FALLBACK_COLOR}`, backgroundColor: "transparent" }
+                    : { backgroundColor: isSkipped ? "#737373" : (typeLookup[w.type]?.color ?? FALLBACK_COLOR) }
+                  }
+                />
+                <span className="text-[10px] font-mono text-foreground/80 truncate">{typeLookup[w.type]?.displayName ?? w.type}</span>
+                {w.duration_min != null && <span className="text-[10px] font-mono text-muted">{w.duration_min}m</span>}
+              </div>
+            );
+          })}
         </div>
       );
     case "nutrition":
@@ -239,7 +257,7 @@ function DayCell({ section, day, typeLookup }: { section: SectionKey; day: DaySu
   }
 }
 
-function SummaryCell({ section, summary, typeLookup }: { section: SectionKey; summary: WeekData["summary"]; typeLookup: WorkoutTypeLookup }) {
+function SummaryCell({ section, summary, typeLookup, planStatus }: { section: SectionKey; summary: WeekData["summary"]; typeLookup: WorkoutTypeLookup; planStatus?: PlanStatusResult | null }) {
   switch (section) {
     case "vitals":
       return (
@@ -258,11 +276,16 @@ function SummaryCell({ section, summary, typeLookup }: { section: SectionKey; su
           {summary.sleep.avgOura != null && <div className="text-[10px] font-mono text-muted">Oura {Math.round(summary.sleep.avgOura)} avg</div>}
         </div>
       );
-    case "workouts":
-      if (summary.workouts.total === 0) return <Empty />;
+    case "workouts": {
+      const completedCount = summary.workouts.total;
+      const plannedTotal = planStatus?.summary.planned ?? 0;
+      if (completedCount === 0 && plannedTotal === 0) return <Empty />;
       return (
         <div>
-          <Val v={summary.workouts.total} u="total" />
+          {plannedTotal > 0
+            ? <Val v={`${planStatus?.summary.completed ?? completedCount}/${plannedTotal}`} u="done" />
+            : <Val v={completedCount} u="total" />
+          }
           <div className="flex flex-wrap gap-1 mt-1">
             {summary.workouts.types.map((t) => (
               <span key={t} className="w-2 h-2 rounded-full" style={{ backgroundColor: typeLookup[t]?.color ?? FALLBACK_COLOR }} />
@@ -270,6 +293,7 @@ function SummaryCell({ section, summary, typeLookup }: { section: SectionKey; su
           </div>
         </div>
       );
+    }
     case "nutrition":
       if (summary.meals.avgDailyProtein == null && summary.meals.avgDailyCalories == null) return <Empty />;
       return (
@@ -304,7 +328,7 @@ function ExpandToggle({ expanded, onToggle }: { expanded: boolean; onToggle: () 
   );
 }
 
-function WorkoutSectionCard({ data, typeLookup }: { data: WeekData; typeLookup: WorkoutTypeLookup }) {
+function WorkoutSectionCard({ data, typeLookup, planStatus }: { data: WeekData; typeLookup: WorkoutTypeLookup; planStatus?: PlanStatusResult | null }) {
   const [expanded, setExpanded] = useState(false);
   const { summary, days } = data;
   const allWorkouts = days.flatMap((d) => d.workouts.map((w) => ({ ...w, dayDate: d.date })));
@@ -321,7 +345,10 @@ function WorkoutSectionCard({ data, typeLookup }: { data: WeekData; typeLookup: 
     <SectionCard title="Workouts" accent="#3b82f6">
       <div className="flex items-baseline justify-between mb-2">
         <p className="text-sm font-mono text-foreground">
-          {summary.workouts.total} workout{summary.workouts.total !== 1 ? "s" : ""}
+          {planStatus
+            ? <>{planStatus.summary.completed}/{planStatus.summary.planned} completed</>
+            : <>{summary.workouts.total} workout{summary.workouts.total !== 1 ? "s" : ""}</>
+          }
           <span className="text-muted ml-1">&middot; {summary.workouts.types.length} type{summary.workouts.types.length !== 1 ? "s" : ""}</span>
         </p>
         <ExpandToggle expanded={expanded} onToggle={() => setExpanded(!expanded)} />

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -15,7 +15,11 @@ import type {
   WorkoutRow,
   WeekData,
   WeekSummary,
+  WeeklyPlan,
+  WeeklyPlanSchedule,
+  WeeklyPlanTargets,
 } from "./types";
+import type { WorkoutStatus } from "./workout-status";
 
 // ─── Day Data ────────────────────────────────────────────
 
@@ -571,7 +575,8 @@ export async function fetchWeekData(startDate: string): Promise<WeekData> {
     if (s.apple_score != null) appleScores.push(s.apple_score);
   }
 
-  const workoutTypes = [...new Set(workouts.map((w) => w.type))];
+  const completedWorkouts = workouts.filter((w) => !(w.planned === true && w.completed === false));
+  const workoutTypes = [...new Set(completedWorkouts.map((w) => w.type))];
   const fastingCompliant = fasting.filter((f) => f.compliant === true).length;
   const pullupTotal = pullups.reduce((sum, p) => sum + p.total_count, 0);
   const mealDays = [...mealTotalsByDate.values()];
@@ -590,7 +595,7 @@ export async function fetchWeekData(startDate: string): Promise<WeekData> {
       daysLogged: allDates.size,
       weight: { first: weightFirst, last: weightLast, delta: weightDelta },
       sleep: { avgHours: avg(sleepHours), avgOura: avg(ouraScores), avgApple: avg(appleScores) },
-      workouts: { total: workouts.length, types: workoutTypes },
+      workouts: { total: completedWorkouts.length, types: workoutTypes },
       meals: {
         avgDailyProtein: mealDays.length > 0 ? avg(mealDays.map((d) => d.protein)) : null,
         avgDailyCalories: mealDays.length > 0 ? avg(mealDays.map((d) => d.calories)) : null,
@@ -639,15 +644,20 @@ export async function fetchWeekSummaries(
   function ensure(monday: string): WeekSummary {
     let s = summaries.get(monday);
     if (!s) {
-      s = { workoutCount: 0, avgSleepHours: null, weightDelta: null, fastingCompliant: 0, fastingTotal: 0 };
+      s = { workoutCount: 0, plannedCount: 0, avgSleepHours: null, weightDelta: null, fastingCompliant: 0, fastingTotal: 0 };
       summaries.set(monday, s);
     }
     return s;
   }
 
-  // Workouts
+  // Workouts — count completed vs planned-only in a single pass
   for (const w of workouts) {
-    ensure(mondayOf(w.date)).workoutCount++;
+    const s = ensure(mondayOf(w.date));
+    if (w.planned === true && w.completed === false) {
+      s.plannedCount++;
+    } else {
+      s.workoutCount++;
+    }
   }
 
   // Sleep — group hours by week for averaging
@@ -690,5 +700,149 @@ export async function fetchWeekSummaries(
   }
 
   return summaries;
+}
+
+// ─── Weekly Plan ─────────────────────────────────────
+
+export async function fetchWeeklyPlan(): Promise<WeeklyPlan | null> {
+  const { data, error } = await supabase
+    .from("weekly_plan")
+    .select("*")
+    .eq("active", true)
+    .order("updated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) return null;
+  return data as unknown as WeeklyPlan | null;
+}
+
+const DAYS_OF_WEEK_Q = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"] as const;
+
+function addDaysStr(dateStr: string, n: number): string {
+  const d = new Date(dateStr + "T00:00:00");
+  d.setDate(d.getDate() + n);
+  return formatDate(d);
+}
+
+export interface PlanDayStatus {
+  date: string;
+  day: string;
+  planned: Array<{ type: string; duration_min?: number; notes?: string; status: WorkoutStatus }>;
+  actual: Array<{ type: string; duration_min: number | null; id: string }>;
+  unplanned: Array<{ type: string; duration_min: number | null; id: string }>;
+}
+
+export interface PlanTargetProgress {
+  total_sessions?: { target: number; actual: number; remaining: number };
+  total_duration_min?: { target: number; actual: number; remaining: number };
+  by_type?: Record<string, {
+    sessions?: { target: number; actual: number };
+    duration_min?: { target: number; actual: number };
+  }>;
+}
+
+export interface PlanStatusResult {
+  week_start: string;
+  template: WeeklyPlanSchedule | null;
+  days: PlanDayStatus[];
+  targets: PlanTargetProgress | null;
+  summary: { planned: number; completed: number; skipped: number; remaining: number };
+}
+
+export async function fetchPlanStatus(weekStart: string): Promise<PlanStatusResult | null> {
+  const plan = await fetchWeeklyPlan();
+  if (!plan) return null;
+
+  const today = formatDate(new Date());
+  const weekEnd = addDaysStr(weekStart, 6);
+
+  const { data: workouts, error } = await supabase
+    .from("workouts")
+    .select("*")
+    .gte("date", weekStart)
+    .lte("date", weekEnd)
+    .order("date")
+    .order("start_time", { ascending: true, nullsFirst: false })
+    .order("created_at");
+
+  if (error) return null;
+  const allWorkouts = (workouts ?? []) as WorkoutRow[];
+
+  const days: PlanDayStatus[] = [];
+  for (let i = 0; i < 7; i++) {
+    const dateStr = addDaysStr(weekStart, i);
+    const dayName = DAYS_OF_WEEK_Q[i];
+    const dayWorkouts = allWorkouts.filter((w) => w.date === dateStr);
+
+    // Split: all planned rows (including completed-in-place) vs non-planned actuals
+    const allPlannedRows = dayWorkouts.filter((w) => w.planned === true);
+    const nonPlannedActual = dayWorkouts.filter((w) => w.planned !== true);
+
+    // Match planned to actuals one-to-one by type (supports duplicate types)
+    const matchedActualIds = new Set<string>();
+    const planned = allPlannedRows.map((pw) => {
+      // Completed in-place — the planned row itself was marked completed
+      if (pw.completed === true) {
+        return { type: pw.type, duration_min: pw.duration_min ?? undefined, notes: pw.notes ?? undefined, status: "completed" as WorkoutStatus };
+      }
+      // Still pending — look for a matching non-planned actual
+      const match = nonPlannedActual.find((a) => a.type === pw.type && !matchedActualIds.has(a.id));
+      if (match) matchedActualIds.add(match.id);
+      const status: WorkoutStatus = match ? "completed" : (dateStr < today ? "skipped" : "scheduled");
+      return { type: pw.type, duration_min: pw.duration_min ?? undefined, notes: pw.notes ?? undefined, status };
+    });
+
+    const unplanned = nonPlannedActual.filter((a) => !matchedActualIds.has(a.id)).map((a) => ({
+      type: a.type, duration_min: a.duration_min, id: a.id,
+    }));
+
+    const matchedActual = nonPlannedActual.filter((a) => matchedActualIds.has(a.id)).map((a) => ({
+      type: a.type, duration_min: a.duration_min, id: a.id,
+    }));
+
+    days.push({ date: dateStr, day: dayName, planned, actual: matchedActual, unplanned });
+  }
+
+  // Targets
+  let targets: PlanTargetProgress | null = null;
+  if (plan.targets) {
+    const completedWorkouts = allWorkouts.filter((w) => !(w.planned === true && w.completed === false));
+    const totalActual = completedWorkouts.length;
+    const totalDuration = completedWorkouts.reduce((s, w) => s + (w.duration_min ?? 0), 0);
+
+    targets = {};
+    if (plan.targets.total_sessions != null) {
+      targets.total_sessions = { target: plan.targets.total_sessions, actual: totalActual, remaining: Math.max(0, plan.targets.total_sessions - totalActual) };
+    }
+    if (plan.targets.total_duration_min != null) {
+      targets.total_duration_min = { target: plan.targets.total_duration_min, actual: totalDuration, remaining: Math.max(0, plan.targets.total_duration_min - totalDuration) };
+    }
+    if (plan.targets.by_type) {
+      targets.by_type = Object.fromEntries(
+        Object.entries(plan.targets.by_type).map(([type, t]) => {
+          const typeWorkouts = completedWorkouts.filter((w) => w.type === type);
+          return [type, {
+            ...(t.sessions != null ? { sessions: { target: t.sessions, actual: typeWorkouts.length } } : {}),
+            ...(t.duration_min != null ? { duration_min: { target: t.duration_min, actual: typeWorkouts.reduce((s, w) => s + (w.duration_min ?? 0), 0) } } : {}),
+          }];
+        }),
+      );
+    }
+  }
+
+  const allPlanned = days.flatMap((d) => d.planned);
+  return {
+    week_start: weekStart,
+    template: plan.schedule,
+    days,
+    targets,
+    summary: {
+      planned: allPlanned.length,
+      completed: allPlanned.filter((p) => p.status === "completed").length,
+      skipped: allPlanned.filter((p) => p.status === "skipped").length,
+      remaining: allPlanned.filter((p) => p.status === "scheduled").length,
+    },
+  };
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -117,6 +117,17 @@ export type Database = {
           updated_at: string | null
         }
       }
+      weekly_plan: {
+        Row: {
+          id: string
+          name: string
+          active: boolean
+          schedule: Record<string, unknown>
+          targets: Record<string, unknown> | null
+          created_at: string | null
+          updated_at: string | null
+        }
+      }
       workout_types: {
         Row: {
           name: string
@@ -153,10 +164,39 @@ export type ViewType = "calendar" | "daily" | "metrics" | "weekly";
 
 export interface WeekSummary {
   workoutCount: number;
+  plannedCount: number;
   avgSleepHours: number | null;
   weightDelta: number | null;
   fastingCompliant: number;
   fastingTotal: number;
+}
+
+export interface PlannedWorkout {
+  type: string;
+  duration_min?: number;
+  notes?: string;
+}
+
+export type DayOfWeek = "monday" | "tuesday" | "wednesday" | "thursday" | "friday" | "saturday" | "sunday";
+
+export interface WeeklyPlanSchedule {
+  [key: string]: PlannedWorkout[];
+}
+
+export interface WeeklyPlanTargets {
+  total_sessions?: number;
+  total_duration_min?: number;
+  by_type?: Record<string, { sessions?: number; duration_min?: number }>;
+}
+
+export interface WeeklyPlan {
+  id: string;
+  name: string;
+  active: boolean;
+  schedule: WeeklyPlanSchedule;
+  targets: WeeklyPlanTargets | null;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface DaySummary {

--- a/src/lib/workout-status.ts
+++ b/src/lib/workout-status.ts
@@ -1,0 +1,11 @@
+import type { WorkoutRow } from "./types";
+
+export type WorkoutStatus = "scheduled" | "skipped" | "completed" | "unplanned";
+
+export function getWorkoutStatus(w: WorkoutRow, today: string): WorkoutStatus {
+  const isPlannedOnly = w.planned === true && w.completed === false;
+  if (isPlannedOnly) {
+    return w.date < today ? "skipped" : "scheduled";
+  }
+  return "completed";
+}

--- a/supabase/migrations/012_weekly_plan.sql
+++ b/supabase/migrations/012_weekly_plan.sql
@@ -1,0 +1,24 @@
+-- Weekly plan template table
+-- Stores reusable weekly workout schedules and targets
+create table weekly_plan (
+  id uuid primary key default gen_random_uuid(),
+  name text not null default 'default',
+  active boolean not null default true,
+  schedule jsonb not null,
+  targets jsonb,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- Trigger for updated_at
+create trigger set_updated_at before update on weekly_plan
+  for each row execute function update_updated_at();
+
+-- RLS
+alter table weekly_plan enable row level security;
+create policy "anon can read weekly_plan" on weekly_plan for select to anon using (true);
+create policy "anon can insert weekly_plan" on weekly_plan for insert to anon with check (true);
+create policy "anon can update weekly_plan" on weekly_plan for update to anon using (true);
+create policy "anon can delete weekly_plan" on weekly_plan for delete to anon using (true);
+
+-- Service role full access (implicit via RLS bypass)

--- a/supabase/migrations/013_fix_workout_planned_default.sql
+++ b/supabase/migrations/013_fix_workout_planned_default.sql
@@ -1,0 +1,8 @@
+-- Change default for planned from true to null
+-- Previously, all logged workouts defaulted to planned=true, which broke
+-- plan-vs-actual matching (every workout appeared to be part of the plan)
+alter table workouts alter column planned set default null;
+
+-- Backfill existing workouts: set planned=null where it was set by the old default
+-- Only update rows that were not explicitly planned (source != 'plan')
+update workouts set planned = null where planned = true and (source is null or source != 'plan');


### PR DESCRIPTION
## Summary

- Add weekly plan template system with schedule, targets, and plan-vs-actual tracking
- 4 new MCP/CLI tools: set_plan, get_plan, instantiate_plan, query_plan
- Visual distinction across all views: hollow dots (scheduled), gray dots (skipped), status badges
- New PlanProgressCard in weekly view showing session/duration/per-type progress
- Fix workout `planned` column default from `true` to `null` with backfill migration

closes #58

## Test plan

- [x] `npm run build` — web compiles
- [x] `cd cli && npm run build` — CLI compiles  
- [x] `cd cli && npm test` — 110 tests pass (unit, CLI, MCP)
- [x] `npx playwright test` — 25 e2e tests pass
- [x] Migrations 012 + 013 applied to remote Supabase
- [x] Code simplified and reviewed (7 rounds: codex + gemini)

🤖 Generated with [Claude Code](https://claude.com/claude-code)