### PR TITLE
Improve sleep card layout and conditional rendering

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,7 +105,7 @@ Source integrations (Apple Health, Oura, Hevy) live in LifeOS, which reconciles 
 | #68 | Add sickness/illness tracking | todo |
 | #77 | Supplements: add replace mode and delete capability | **done** |
 | #78 | Replace hardcoded sleep booleans with flexible sleep tags | **done** |
-| #79 | Expand Vitals section with more daily metrics | todo |
+| #79 | Expand Vitals section with more daily metrics | **done** |
 
 ## Testing
 

--- a/src/components/day-detail/section-sleep.tsx
+++ b/src/components/day-detail/section-sleep.tsx
@@ -12,35 +12,73 @@ export default function SectionSleep({
   sleepTags?: MetricRow[];
   prKeys?: Set<string>;
 }) {
+  // Build stats array — only include fields that have data
+  const stats: {
+    label: string;
+    value: number | string;
+    unit?: string;
+    indicator?: "pr" | "streak";
+  }[] = [];
+
+  if (data?.hours != null)
+    stats.push({
+      label: "Hours",
+      value: data.hours,
+      indicator: prKeys?.has("sleep_hours") ? "pr" : undefined,
+    });
+  if (data?.apple_score != null)
+    stats.push({ label: "🍎 Apple", value: data.apple_score });
+  if (data?.oura_score != null)
+    stats.push({
+      label: "◎ Oura",
+      value: data.oura_score,
+      indicator: prKeys?.has("sleep_oura") ? "pr" : undefined,
+    });
+  if (data?.oura_readiness != null)
+    stats.push({ label: "◎ Readiness", value: data.oura_readiness });
+  if (data?.avg_hrv != null)
+    stats.push({ label: "Avg HRV", value: data.avg_hrv, unit: "ms" });
+  if (data?.avg_hr_sleep != null)
+    stats.push({ label: "Avg HR", value: data.avg_hr_sleep, unit: "bpm" });
+
+  // Only show active badges (cpap=true, mouth_tape=true, logged sleep tags)
+  const activeBadges: string[] = [];
+  if (data?.cpap) activeBadges.push("CPAP");
+  if (data?.mouth_tape) activeBadges.push("Mouth Tape");
+
+  const hasContent =
+    stats.length > 0 || activeBadges.length > 0 || sleepTags.length > 0 || !!data?.notes;
+
   return (
-    <SectionCard title="Sleep" accent="#8b5cf6" empty={!data && sleepTags.length === 0}>
-      {(data || sleepTags.length > 0) && (
+    <SectionCard title="Sleep" accent="#8b5cf6" empty={!hasContent}>
+      {hasContent && (
         <div className="space-y-3">
-          {data && (
+          {stats.length > 0 && (
             <div className="grid grid-cols-2 gap-4">
-              <Stat label="Apple Score" value={data.apple_score} />
-              <Stat
-                label="Oura Score"
-                value={data.oura_score}
-                indicator={prKeys?.has("sleep_oura") ? "pr" : undefined}
-              />
-              <Stat
-                label="Hours"
-                value={data.hours}
-                indicator={prKeys?.has("sleep_hours") ? "pr" : undefined}
-              />
-              <Stat label="Oura Readiness" value={data.oura_readiness} />
-              <Stat label="Avg HRV" value={data.avg_hrv} unit="ms" />
-              <Stat label="Avg HR (Sleep)" value={data.avg_hr_sleep} unit="bpm" />
+              {stats.map((s) => (
+                <Stat
+                  key={s.label}
+                  label={s.label}
+                  value={s.value}
+                  unit={s.unit}
+                  indicator={s.indicator}
+                />
+              ))}
             </div>
           )}
-          <div className="flex gap-2 flex-wrap">
-            {data?.cpap != null && <Badge label="CPAP" active={data.cpap} />}
-            {data?.mouth_tape != null && <Badge label="Mouth Tape" active={data.mouth_tape} />}
-            {sleepTags.map((tag) => (
-              <Badge key={tag.id} label={tag.metric_name.replace(/-/g, " ")} />
-            ))}
-          </div>
+          {(activeBadges.length > 0 || sleepTags.length > 0) && (
+            <div className="flex gap-2 flex-wrap">
+              {activeBadges.map((label) => (
+                <Badge key={label} label={label} />
+              ))}
+              {sleepTags.map((tag) => (
+                <Badge
+                  key={tag.id}
+                  label={tag.metric_name.replace(/-/g, " ")}
+                />
+              ))}
+            </div>
+          )}
           {data?.notes && (
             <p className="text-sm text-foreground/80">{data.notes}</p>
           )}


### PR DESCRIPTION
## Summary
- Only render sleep stats that have data — no more "--" placeholders for missing values
- Add source icons (🍎 Apple, ◎ Oura) to differentiate score origins
- Show Hours first in the grid for prominence
- Only show CPAP/Mouth Tape badges when active (previously showed dimmed when false)
- Handle all-null sleep rows as empty state (shows "Not logged" instead of blank card)

## Test plan
- [x] `npm run build` — compiles clean
- [x] `npx playwright test` — 25/25 pass
- [ ] Visual: day with both Apple + Oura scores shows icons
- [ ] Visual: day with only one source hides the other (no "--")
- [ ] Visual: CPAP badge only appears when used

closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)