### PR TITLE
Add structured Oura sleep sub-scores

### DIFF
--- a/cli/src/commands/log.ts
+++ b/cli/src/commands/log.ts
@@ -12,7 +12,16 @@ export async function logDaily(date: string, fields: { weight?: number; energy?:
   return upsertRow("daily_entries", { date, ...sparse(fields) });
 }
 
-export async function logSleep(date: string, fields: { apple_score?: number; oura_score?: number; hours?: number; cpap?: boolean; mouth_tape?: boolean; oura_readiness?: number; avg_hr_sleep?: number; avg_hrv?: number; notes?: string }) {
+export type SleepFields = {
+  apple_score?: number; oura_score?: number; hours?: number;
+  cpap?: boolean; mouth_tape?: boolean;
+  oura_readiness?: number; avg_hr_sleep?: number; avg_hrv?: number;
+  oura_deep?: number; oura_efficiency?: number; oura_latency?: number;
+  oura_rem?: number; oura_restfulness?: number; oura_timing?: number; oura_total?: number;
+  notes?: string;
+};
+
+export async function logSleep(date: string, fields: SleepFields) {
   await ensureDailyEntry(date);
   return upsertRow("sleep", { date, ...sparse(fields) });
 }
@@ -181,6 +190,13 @@ export function registerLogCommands(program: Command): void {
     .option("--readiness <score>", "Oura readiness score")
     .option("--avg-hr-sleep <bpm>", "Average heart rate during sleep")
     .option("--hrv <ms>", "Average HRV")
+    .option("--oura-deep <score>", "Oura deep sleep score (0-100)")
+    .option("--oura-efficiency <score>", "Oura efficiency score (0-100)")
+    .option("--oura-latency <score>", "Oura latency score (0-100)")
+    .option("--oura-rem <score>", "Oura REM score (0-100)")
+    .option("--oura-restfulness <score>", "Oura restfulness score (0-100)")
+    .option("--oura-timing <score>", "Oura timing score (0-100)")
+    .option("--oura-total <score>", "Oura total sleep score (0-100)")
     .option("--notes <text>", "Notes")
     .action(async (opts) => {
       try {
@@ -193,6 +209,13 @@ export function registerLogCommands(program: Command): void {
           oura_readiness: parseNum("readiness", opts.readiness),
           avg_hr_sleep: parseNum("avg-hr-sleep", opts.avgHrSleep),
           avg_hrv: parseNum("hrv", opts.hrv),
+          oura_deep: parseNum("oura-deep", opts.ouraDeep),
+          oura_efficiency: parseNum("oura-efficiency", opts.ouraEfficiency),
+          oura_latency: parseNum("oura-latency", opts.ouraLatency),
+          oura_rem: parseNum("oura-rem", opts.ouraRem),
+          oura_restfulness: parseNum("oura-restfulness", opts.ouraRestfulness),
+          oura_timing: parseNum("oura-timing", opts.ouraTiming),
+          oura_total: parseNum("oura-total", opts.ouraTotal),
           notes: opts.notes as string | undefined,
         });
         success(result);

--- a/cli/src/mcp.ts
+++ b/cli/src/mcp.ts
@@ -105,6 +105,13 @@ server.registerTool("ironcompass_log_sleep", {
     oura_readiness: z.number().optional().describe("Oura readiness score"),
     avg_hr_sleep: z.number().optional().describe("Average heart rate during sleep"),
     avg_hrv: z.number().optional().describe("Average HRV"),
+    oura_deep: z.number().optional().describe("Oura deep sleep sub-score (0-100)"),
+    oura_efficiency: z.number().optional().describe("Oura efficiency sub-score (0-100)"),
+    oura_latency: z.number().optional().describe("Oura latency sub-score (0-100)"),
+    oura_rem: z.number().optional().describe("Oura REM sub-score (0-100)"),
+    oura_restfulness: z.number().optional().describe("Oura restfulness sub-score (0-100)"),
+    oura_timing: z.number().optional().describe("Oura timing sub-score (0-100)"),
+    oura_total: z.number().optional().describe("Oura total sleep sub-score (0-100)"),
     notes: z.string().optional(),
   }),
 }, async ({ date, ...fields }) => {

--- a/cli/src/types/database.ts
+++ b/cli/src/types/database.ts
@@ -385,8 +385,15 @@ export type Database = {
           hours: number | null
           mouth_tape: boolean | null
           notes: string | null
+          oura_deep: number | null
+          oura_efficiency: number | null
+          oura_latency: number | null
           oura_readiness: number | null
+          oura_rem: number | null
+          oura_restfulness: number | null
           oura_score: number | null
+          oura_timing: number | null
+          oura_total: number | null
           updated_at: string | null
         }
         Insert: {
@@ -399,8 +406,15 @@ export type Database = {
           hours?: number | null
           mouth_tape?: boolean | null
           notes?: string | null
+          oura_deep?: number | null
+          oura_efficiency?: number | null
+          oura_latency?: number | null
           oura_readiness?: number | null
+          oura_rem?: number | null
+          oura_restfulness?: number | null
           oura_score?: number | null
+          oura_timing?: number | null
+          oura_total?: number | null
           updated_at?: string | null
         }
         Update: {
@@ -413,8 +427,15 @@ export type Database = {
           hours?: number | null
           mouth_tape?: boolean | null
           notes?: string | null
+          oura_deep?: number | null
+          oura_efficiency?: number | null
+          oura_latency?: number | null
           oura_readiness?: number | null
+          oura_rem?: number | null
+          oura_restfulness?: number | null
           oura_score?: number | null
+          oura_timing?: number | null
+          oura_total?: number | null
           updated_at?: string | null
         }
         Relationships: [

--- a/src/components/day-detail/section-sleep.tsx
+++ b/src/components/day-detail/section-sleep.tsx
@@ -40,6 +40,18 @@ export default function SectionSleep({
     stats.push({ label: "Avg HRV", value: data.avg_hrv, unit: "ms" });
   if (data?.avg_hr_sleep != null)
     stats.push({ label: "Avg HR", value: data.avg_hr_sleep, unit: "bpm" });
+  const OURA_SUBSCORES: { key: keyof SleepRow; label: string }[] = [
+    { key: "oura_total", label: "◎ Total" },
+    { key: "oura_deep", label: "◎ Deep" },
+    { key: "oura_rem", label: "◎ REM" },
+    { key: "oura_efficiency", label: "◎ Efficiency" },
+    { key: "oura_latency", label: "◎ Latency" },
+    { key: "oura_restfulness", label: "◎ Restful" },
+    { key: "oura_timing", label: "◎ Timing" },
+  ];
+  for (const { key, label } of OURA_SUBSCORES) {
+    if (data?.[key] != null) stats.push({ label, value: data[key] as number });
+  }
 
   // Only show active badges (cpap=true, mouth_tape=true, logged sleep tags)
   const activeBadges: string[] = [];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -128,8 +128,15 @@ export type Database = {
           hours: number | null
           mouth_tape: boolean | null
           notes: string | null
+          oura_deep: number | null
+          oura_efficiency: number | null
+          oura_latency: number | null
           oura_readiness: number | null
+          oura_rem: number | null
+          oura_restfulness: number | null
           oura_score: number | null
+          oura_timing: number | null
+          oura_total: number | null
           updated_at: string | null
         }
       }

--- a/supabase/migrations/016_add_oura_subscores.sql
+++ b/supabase/migrations/016_add_oura_subscores.sql
@@ -1,0 +1,8 @@
+-- Add Oura sleep sub-scores as structured columns
+alter table sleep add column oura_deep integer check (oura_deep between 0 and 100);
+alter table sleep add column oura_efficiency integer check (oura_efficiency between 0 and 100);
+alter table sleep add column oura_latency integer check (oura_latency between 0 and 100);
+alter table sleep add column oura_rem integer check (oura_rem between 0 and 100);
+alter table sleep add column oura_restfulness integer check (oura_restfulness between 0 and 100);
+alter table sleep add column oura_timing integer check (oura_timing between 0 and 100);
+alter table sleep add column oura_total integer check (oura_total between 0 and 100);


### PR DESCRIPTION
## Summary

- Add 7 Oura sleep sub-score columns (`oura_deep`, `oura_efficiency`, `oura_latency`, `oura_rem`, `oura_restfulness`, `oura_timing`, `oura_total`) as structured integer fields with 0-100 check constraints
- Expose sub-scores via CLI (`--oura-deep`, etc.), MCP tool (`ironcompass_log_sleep`), and dashboard day-detail view with `◎` prefix labels
- Extract `SleepFields` type for maintainability; use data-driven loop for sub-score rendering

closes #83

## Test plan

- [x] `npm run build` — compiles clean
- [x] `cd cli && npm run build` — CLI compiles clean
- [x] `npx playwright test` — all 25 tests pass
- [ ] Apply migration SQL in Supabase dashboard
- [ ] Log sleep with sub-scores via MCP, verify day-detail view renders them

🤖 Generated with [Claude Code](https://claude.com/claude-code)